### PR TITLE
Add dynamic teachers section and paginated listing

### DIFF
--- a/assets/teachers/info.txt
+++ b/assets/teachers/info.txt
@@ -1,0 +1,20 @@
+MUHAMMAD TOHA
+ID : 201802018
+Designation : Associate Professor
+Subject : Islamic Studies
+Blood Group : B+
+Mobile : 8801748977352
+
+FATEMA AKTER
+ID : 201802019
+Designation : Lecturer
+Subject : Mathematics
+Blood Group : O-
+Mobile : 8801700000000
+
+MD ABDUR RAHMAN
+ID : 201802020
+Designation : Assistant Professor
+Subject : Physics
+Blood Group : A+
+Mobile : 8801711111111

--- a/components/teachers.js
+++ b/components/teachers.js
@@ -1,0 +1,91 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  const root = window.location.pathname.includes('/pages/') ? '../' : '';
+  fetch(root + 'assets/teachers/info.txt')
+    .then(r=>r.text())
+    .then(t=>{
+      const teachers=parseTeachers(t);
+      renderHome(teachers,root);
+      renderTeachersPage(teachers,root);
+    }).catch(()=>{});
+});
+
+function parseTeachers(text){
+  return text.split(/\n\s*\n/).map(block=>{
+    const lines=block.trim().split(/\n/);
+    if(!lines[0]) return null;
+    const teacher={name:lines[0].trim()};
+    for(let i=1;i<lines.length;i++){
+      const [key,...rest]=lines[i].split(':');
+      if(!key||rest.length===0) continue;
+      teacher[key.trim().toLowerCase()]=rest.join(':').trim();
+    }
+    return teacher.id?teacher:null;
+  }).filter(Boolean);
+}
+
+function createCard(t,root,full){
+  const card=document.createElement('article');
+  card.className='bg-white border border-gray-200 rounded-xl shadow p-4 flex flex-col items-center text-center';
+  const img=document.createElement('img');
+  img.loading='lazy';
+  img.src=root+'assets/teachers/pictures/'+t.id+'.jpg';
+  img.alt=t.name;
+  img.className='w-32 h-32 object-cover rounded-full mb-3';
+  img.onerror=()=>{img.remove();};
+  card.appendChild(img);
+  const name=document.createElement('h4');
+  name.className='font-bold';
+  name.textContent=t.name;
+  card.appendChild(name);
+  const des=document.createElement('p');
+  des.className='text-sm';
+  des.textContent=t['designation']||'';
+  card.appendChild(des);
+  if(full){
+    const id=document.createElement('p');
+    id.className='text-sm';
+    id.textContent='ID: '+(t['id']||'');
+    card.appendChild(id);
+    const subj=document.createElement('p');
+    subj.className='text-sm';
+    subj.textContent='Subject: '+(t['subject']||'');
+    card.appendChild(subj);
+    const blood=document.createElement('p');
+    blood.className='text-sm';
+    blood.textContent='Blood Group: '+(t['blood group']||'');
+    card.appendChild(blood);
+    const mob=document.createElement('p');
+    mob.className='text-sm';
+    mob.textContent='Mobile: '+(t['mobile']||'');
+    card.appendChild(mob);
+  }
+  return card;
+}
+
+function renderHome(teachers,root){
+  const wrap=document.getElementById('teachersHome');
+  if(!wrap) return;
+  teachers.slice(0,3).forEach(t=>wrap.appendChild(createCard(t,root,false)));
+}
+
+function renderTeachersPage(teachers,root){
+  const wrap=document.getElementById('teachersAll');
+  if(!wrap) return;
+  const perPage=20;
+  const params=new URLSearchParams(window.location.search);
+  let page=parseInt(params.get('page')||'1',10);if(isNaN(page)||page<1) page=1;
+  const totalPages=Math.max(1,Math.ceil(teachers.length/perPage));
+  if(page>totalPages) page=totalPages;
+  const start=(page-1)*perPage;
+  teachers.slice(start,start+perPage).forEach(t=>wrap.appendChild(createCard(t,root,true)));
+  const pag=document.getElementById('teacherPagination');
+  if(pag){
+    for(let i=1;i<=totalPages;i++){
+      const a=document.createElement('a');
+      a.textContent=i;
+      a.href='teachers.html?page='+i;
+      a.className='px-3 py-1 border rounded '+(i===page?'bg-gray-200 pointer-events-none':'bg-white');
+      pag.appendChild(a);
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -88,8 +88,10 @@
 <section id="leadership" class="section"><div class="wrap"><div class="head"><h2>Leadership</h2><span class="muted">Student messages from leadership</span></div><div class="leaders"><article class="leader" data-info="assets/leaders/leader-1.txt"><img loading="lazy" src="assets/leaders/leader-1.png" alt="Chief Patron"><div class="info"><h4>Chief Patron</h4><p class="name">Loading...</p><a class="chip" href="#">Click to See Message</a></div></article><article class="leader" data-info="assets/leaders/leader-2.txt"><img loading="lazy" src="assets/leaders/leader-2.png" alt="Chairman"><div class="info"><h4>Chairman</h4><p class="name">Loading...</p><a class="chip" href="#">Click to See Message</a></div></article><article class="leader" data-info="assets/leaders/leader-3.txt"><img loading="lazy" src="assets/leaders/leader-3.png" alt="Principal"><div class="info"><h4>Principal</h4><p class="name">Loading...</p><a class="chip" href="#">Click to See Message</a></div></article></div></div></section>
   <div class="divider wave" aria-hidden="true"></div>
 
-<section id="achievements" class="section"><div class="wrap"><div class="head"><h2>Achievements</h2><span class="muted">Be a Champion</span></div><div class="counters"><div class="counter"><span data-count="38">0</span><label>Competition Trophies</label></div><div class="counter"><span data-count="12">0</span><label>Active Clubs</label></div><div class="counter"><span data-count="120">0</span><label>Total Teachers</label></div></div><div class="mt-6 flex flex-col md:flex-row items-center gap-6"><img loading="lazy" class="rounded-xl shadow" src="assets/achievement-placeholder.png" alt="Champion team"></div></div></section>
+  <section id="achievements" class="section"><div class="wrap"><div class="head"><h2>Achievements</h2><span class="muted">Be a Champion</span></div><div class="counters"><div class="counter"><span data-count="38">0</span><label>Competition Trophies</label></div><div class="counter"><span data-count="12">0</span><label>Active Clubs</label></div><div class="counter"><span data-count="120">0</span><label>Total Teachers</label></div></div><div class="mt-6 flex flex-col md:flex-row items-center gap-6"><img loading="lazy" class="rounded-xl shadow" src="assets/achievement-placeholder.png" alt="Champion team"></div></div></section>
   <div class="divider wave flip" aria-hidden="true"></div>
+  <section id="teachers" class="section"><div class="wrap"><div class="head"><h2>Our Respected Teachers</h2></div><div id="teachersHome" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div><div class="mt-6 text-center"><a class="cta green" href="pages/teachers.html">See More</a></div></div></section>
+  <div class="divider wave" aria-hidden="true"></div>
 
   <section id="academics" class="section"><div class="wrap"><div class="head"><h2>Academics</h2><span class="muted">Curriculum • HSC • ICT</span></div><div class="grid cards"><article class="card pop"><h3>Curriculum</h3><p>Grade 6–10 • HSC Science, Commerce, Arts.</p></article><article id="resources" class="card pop"><h3>Resources</h3><p>Syllabus & Notes (PDF), Question Bank, e-Library.</p></article><article class="card pop"><h3>Exams</h3><p>Term Exams, Model Tests, Practicals, Results.</p></article></div></div></section>
 
@@ -205,7 +207,8 @@
       <span>© <span data-year></span> Ispahani Cantonment Public School & College</span>
     </div>
   </div>
-</footer>
-  <script src="components/common.js"></script>
-</body>
-</html>
+  </footer>
+    <script src="components/teachers.js"></script>
+    <script src="components/common.js"></script>
+  </body>
+  </html>

--- a/pages/teachers.html
+++ b/pages/teachers.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="bn">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Teachers - Ispahani Cantonment Public School & College</title>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Bengali:wght@400;600;700&family=Inter:wght@500;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+  <link rel="stylesheet" href="../components/common.css"/>
+</head>
+<body class="text-slate-800 selection:bg-[#ffd166]/60">
+  <div id="decor"></div>
+<div id="masthead">
+  <div class="topbar"><div class="wrap"><span>EIIN 105826</span><span>College 7925</span><span>School 7801</span></div></div>
+  <header class="header">
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <img id="logoImg" src="../assets/ipsc-logo.png" alt="Logo">
+      <div class="btext"><strong>Ispahani Cantonment Public School & College</strong><span>Comilla Cantonment</span></div>
+    </a>
+    <div class="controls">
+      <nav class="nav" aria-label="Primary">
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <a class="nav-btn" href="apply.html">Apply</a>
+        <a id="loginNav" class="cta red" href="#login">Login</a>
+      </nav>
+      <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
+    </div>
+  </div>
+  <div id="mobileNav" class="mob hidden">
+    <a class="mlink" href="../index.html">Home</a>
+    <div class="mitem">
+      <button class="mhead">Academics</button>
+      <div class="msub">
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
+      </div>
+    </div>
+    <div class="mitem">
+      <button class="mhead">Campus</button>
+      <div class="msub">
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
+      </div>
+    </div>
+    <a class="mlink" href="apply.html">Apply</a>
+    <a id="loginNavM" class="mlink special" href="#login">Login</a>
+  </div>
+  </header>
+  <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>
+</div>
+<div id="loginModal" class="fixed inset-0 bg-black/60 hidden flex items-center justify-center z-50">
+  <div class="bg-white p-6 rounded-xl w-80 shadow">
+    <h3 class="font-bold mb-4 text-center">Admin Login</h3>
+    <label class="block mb-2 text-sm">User ID</label>
+    <input id="loginUser" type="text" class="w-full border border-gray-300 bg-white p-2 rounded">
+    <label class="block mt-4 mb-2 text-sm">Password</label>
+    <input id="loginPass" type="password" class="w-full border border-gray-300 bg-white p-2 rounded">
+    <div class="mt-4 flex justify-end gap-2">
+      <button id="loginCancel" class="ghost">Cancel</button>
+      <button id="loginOk" class="cta green">Login</button>
+    </div>
+  </div>
+</div>
+  <div id="msgModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-[100] p-4">
+    <div class="msg-box text-[#0f172a] p-6 rounded-xl shadow relative w-full max-w-lg h-96 overflow-y-auto">
+      <button id="msgClose" class="absolute top-2 right-2 text-2xl leading-none" aria-label="Close">×</button>
+      <h3 id="msgTitle" class="font-bold text-center mb-4"></h3>
+      <div id="msgText" class="whitespace-pre-line"></div>
+    </div>
+  </div>
+
+  <section class="section"><div class="wrap"><h1 class="grad">Teachers</h1><div id="teachersAll" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"></div><div id="teacherPagination" class="mt-6 flex justify-center gap-2"></div></div></section>
+
+<footer class="footer">
+  <div class="wrap">
+    <div class="grid gap-6 md:grid-cols-2 text-center md:text-left">
+      <div class="contact">
+        <h4 class="font-bold mb-2">Contact</h4>
+        <p>Cumilla Cantonment 3501, Cumilla</p>
+        <p>Phone: 03239933170</p>
+        <p>Mobile: 01733063001</p>
+        <p>Email: ipscm1@gmail.com</p>
+      </div>
+      <div class="links">
+        <h4 class="font-bold mb-2">গুরুত্বপূর্ণ লিঙ্ক</h4>
+        <ul class="space-y-1">
+          <li><a class="link" href="https://comillaboard.portal.gov.bd/" target="_blank" rel="noopener">Comilla Education Board</a></li>
+          <li><a class="link" href="https://shed.gov.bd/" target="_blank" rel="noopener">মাধ্যমিক ও উচ্চ শিক্ষা বিভাগ</a></li>
+          <li><a class="link" href="https://bangladesh.gov.bd/index.php" target="_blank" rel="noopener">বাংলাদেশ জাতীয় শিক্ষা বাতায়ন</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="mt-6 pt-4 border-t flex flex-col md:flex-row justify-between items-center text-sm">
+      <span>© <span data-year></span> Mahfuz Alam Shohan</span>
+      <span>© <span data-year></span> Ispahani Cantonment Public School & College</span>
+    </div>
+  </div>
+</footer>
+  <script src="../components/teachers.js"></script>
+  <script src="../components/common.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `Our Respected Teachers` section on homepage showing first three teachers from `assets/teachers/info.txt`
- Create dedicated `teachers.html` page with shared layout and pagination (20 per page)
- Implement `components/teachers.js` to parse teacher info, render cards, and use ID-based photos without placeholder fallback

## Testing
- `node --version`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68bc57b6cb90832b879e0fc0e0ee7ba4