### PR TITLE
Improve teachers section layout

### DIFF
--- a/components/teachers.js
+++ b/components/teachers.js
@@ -25,7 +25,13 @@ function parseTeachers(text){
 
 function createCard(t,root,full){
   const card=document.createElement('article');
-  card.className='bg-white border border-gray-200 rounded-xl shadow p-4 flex flex-col items-center text-center';
+  card.className='relative bg-white border border-gray-200 rounded-xl shadow-md p-4 flex flex-col items-center text-center overflow-hidden transition-transform hover:-translate-y-1 hover:shadow-lg';
+  const art=document.createElement('div');
+  art.className='absolute -top-8 -right-8 w-24 h-24 rounded-full bg-[#ffd166] opacity-20 -z-10 pointer-events-none';
+  const art2=document.createElement('div');
+  art2.className='absolute -bottom-8 -left-8 w-24 h-24 rounded-full bg-[#06d6a0] opacity-20 -z-10 pointer-events-none';
+  card.appendChild(art);
+  card.appendChild(art2);
   const img=document.createElement('img');
   img.loading='lazy';
   img.src=root+'assets/teachers/pictures/'+t.id+'.jpg';
@@ -65,19 +71,19 @@ function createCard(t,root,full){
 function renderHome(teachers,root){
   const wrap=document.getElementById('teachersHome');
   if(!wrap) return;
-  teachers.slice(0,3).forEach(t=>wrap.appendChild(createCard(t,root,false)));
+  teachers.slice(0,8).forEach(t=>wrap.appendChild(createCard(t,root,false)));
 }
 
 function renderTeachersPage(teachers,root){
   const wrap=document.getElementById('teachersAll');
   if(!wrap) return;
-  const perPage=20;
+  const perPage=8;
   const params=new URLSearchParams(window.location.search);
   let page=parseInt(params.get('page')||'1',10);if(isNaN(page)||page<1) page=1;
   const totalPages=Math.max(1,Math.ceil(teachers.length/perPage));
   if(page>totalPages) page=totalPages;
   const start=(page-1)*perPage;
-  teachers.slice(start,start+perPage).forEach(t=>wrap.appendChild(createCard(t,root,true)));
+  teachers.slice(start,start+perPage).forEach(t=>wrap.appendChild(createCard(t,root,false)));
   const pag=document.getElementById('teacherPagination');
   if(pag){
     for(let i=1;i<=totalPages;i++){

--- a/pages/teachers.html
+++ b/pages/teachers.html
@@ -79,7 +79,7 @@
     </div>
   </div>
 
-  <section class="section"><div class="wrap"><h1 class="grad">Teachers</h1><div id="teachersAll" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"></div><div id="teacherPagination" class="mt-6 flex justify-center gap-2"></div></div></section>
+<section class="section"><div class="wrap"><h1 class="grad">Teachers</h1><div id="teachersAll" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div><div id="teacherPagination" class="mt-6 flex justify-center gap-2"></div></div></section>
 
 <footer class="footer">
   <div class="wrap">


### PR DESCRIPTION
## Summary
- show eight teacher cards on home page for a full two-row layout
- restyle teacher cards with decorative accents for a magazine-like appearance
- display teachers in four-column grid with two rows per page

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5db329c4832bad3df759e21476e5