### PR TITLE
Improve teachers display and navigation

### DIFF
--- a/components/teachers.js
+++ b/components/teachers.js
@@ -25,7 +25,7 @@ function parseTeachers(text){
 
 function createCard(t,root,full){
   const card=document.createElement('article');
-  card.className='relative bg-white border border-gray-200 rounded-xl shadow-md p-4 flex flex-col items-center text-center overflow-hidden transition-transform hover:-translate-y-1 hover:shadow-lg';
+  card.className='relative bg-gradient-to-br from-white via-yellow-50 to-green-50 border border-gray-200 rounded-xl shadow-lg p-4 flex flex-col items-center text-center overflow-hidden';
   const art=document.createElement('div');
   art.className='absolute -top-8 -right-8 w-24 h-24 rounded-full bg-[#ffd166] opacity-20 -z-10 pointer-events-none';
   const art2=document.createElement('div');
@@ -36,7 +36,7 @@ function createCard(t,root,full){
   img.loading='lazy';
   img.src=root+'assets/teachers/pictures/'+t.id+'.jpg';
   img.alt=t.name;
-  img.className='w-32 h-32 object-cover rounded-full mb-3';
+  img.className='w-32 h-32 object-cover rounded-full mb-3 cursor-pointer';
   img.onerror=()=>{img.remove();};
   card.appendChild(img);
   const name=document.createElement('h4');
@@ -64,6 +64,8 @@ function createCard(t,root,full){
     mob.className='text-sm';
     mob.textContent='Mobile: '+(t['mobile']||'');
     card.appendChild(mob);
+  }else{
+    img.addEventListener('click',()=>{window.location.href=root+'pages/teachers.html';});
   }
   return card;
 }
@@ -71,19 +73,20 @@ function createCard(t,root,full){
 function renderHome(teachers,root){
   const wrap=document.getElementById('teachersHome');
   if(!wrap) return;
-  teachers.slice(0,8).forEach(t=>wrap.appendChild(createCard(t,root,false)));
+  const max=window.matchMedia('(min-width:1024px)').matches?8:6;
+  teachers.slice(0,max).forEach(t=>wrap.appendChild(createCard(t,root,false)));
 }
 
 function renderTeachersPage(teachers,root){
   const wrap=document.getElementById('teachersAll');
   if(!wrap) return;
-  const perPage=8;
+  const perPage=24;
   const params=new URLSearchParams(window.location.search);
   let page=parseInt(params.get('page')||'1',10);if(isNaN(page)||page<1) page=1;
   const totalPages=Math.max(1,Math.ceil(teachers.length/perPage));
   if(page>totalPages) page=totalPages;
   const start=(page-1)*perPage;
-  teachers.slice(start,start+perPage).forEach(t=>wrap.appendChild(createCard(t,root,false)));
+  teachers.slice(start,start+perPage).forEach(t=>wrap.appendChild(createCard(t,root,true)));
   const pag=document.getElementById('teacherPagination');
   if(pag){
     for(let i=1;i<=totalPages;i++){

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
         <a class="nav-btn" href="index.html">Home</a>
         <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="#houses">Houses</a><a href="#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="#resources">Syllabus (PDF)</a><a href="#resources">Question Bank</a><a href="#resources">e-Library</a></div></div></div>
         <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="#facilities">Labs & Library</a><a href="#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="pages/clubs.html">Clubs & Societies</a><a href="#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="pages/teachers.html">Teachers</a><a href="pages/staffs.html">Staffs</a><a href="pages/governing.html">Governing Body</a></div></div></div>
         <a class="nav-btn" href="pages/apply.html">Apply</a>
         <a id="loginNav" class="cta red" href="#login">Login</a>
       </nav>
@@ -50,6 +51,14 @@
         <a class="mlink" href="#facilities">Playgrounds</a>
         <a class="mlink" href="pages/clubs.html">Clubs &amp; Societies</a>
         <a class="mlink" href="#gallery">Gallery</a>
+      </div>
+    </div>
+    <div class="mitem">
+      <button class="mhead">Administration</button>
+      <div class="msub">
+        <a class="mlink" href="pages/teachers.html">Teachers</a>
+        <a class="mlink" href="pages/staffs.html">Staffs</a>
+        <a class="mlink" href="pages/governing.html">Governing Body</a>
       </div>
     </div>
     <a class="mlink" href="pages/apply.html">Apply</a>
@@ -90,7 +99,7 @@
 
   <section id="achievements" class="section"><div class="wrap"><div class="head"><h2>Achievements</h2><span class="muted">Be a Champion</span></div><div class="counters"><div class="counter"><span data-count="38">0</span><label>Competition Trophies</label></div><div class="counter"><span data-count="12">0</span><label>Active Clubs</label></div><div class="counter"><span data-count="120">0</span><label>Total Teachers</label></div></div><div class="mt-6 flex flex-col md:flex-row items-center gap-6"><img loading="lazy" class="rounded-xl shadow" src="assets/achievement-placeholder.png" alt="Champion team"></div></div></section>
   <div class="divider wave flip" aria-hidden="true"></div>
-  <section id="teachers" class="section"><div class="wrap"><div class="head"><h2>Our Respected Teachers</h2></div><div id="teachersHome" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div><div class="mt-6 text-center"><a class="cta green" href="pages/teachers.html">See More</a></div></div></section>
+  <section id="teachers" class="section"><div class="wrap"><div class="head"><h2>Our Respected Teachers</h2></div><div id="teachersHome" class="grid gap-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4"></div><div class="mt-6 text-center"><a class="cta green" href="pages/teachers.html">See More</a></div></div></section>
   <div class="divider wave" aria-hidden="true"></div>
 
   <section id="academics" class="section"><div class="wrap"><div class="head"><h2>Academics</h2><span class="muted">Curriculum • HSC • ICT</span></div><div class="grid cards"><article class="card pop"><h3>Curriculum</h3><p>Grade 6–10 • HSC Science, Commerce, Arts.</p></article><article id="resources" class="card pop"><h3>Resources</h3><p>Syllabus & Notes (PDF), Question Bank, e-Library.</p></article><article class="card pop"><h3>Exams</h3><p>Term Exams, Model Tests, Practicals, Results.</p></article></div></div></section>

--- a/pages/clubs.html
+++ b/pages/clubs.html
@@ -25,6 +25,7 @@
         <a class="nav-btn" href="../index.html">Home</a>
         <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
         <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a><a href="governing.html">Governing Body</a></div></div></div>
         <a class="nav-btn" href="apply.html">Apply</a>
         <a id="loginNav" class="cta red" href="#login">Login</a>
       </nav>
@@ -50,6 +51,14 @@
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
         <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
         <a class="mlink" href="../index.html#gallery">Gallery</a>
+      </div>
+    </div>
+    <div class="mitem">
+      <button class="mhead">Administration</button>
+      <div class="msub">
+        <a class="mlink" href="teachers.html">Teachers</a>
+        <a class="mlink" href="staffs.html">Staffs</a>
+        <a class="mlink" href="governing.html">Governing Body</a>
       </div>
     </div>
     <a class="mlink" href="apply.html">Apply</a>

--- a/pages/governing.html
+++ b/pages/governing.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Apply Online - Ispahani Cantonment Public School & College</title>
+  <title>Governing Body - Ispahani Cantonment Public School & College</title>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Bengali:wght@400;600;700&family=Inter:wght@500;700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
@@ -80,15 +80,15 @@
     </div>
   </div>
 </div>
-  <div id="msgModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-[100] p-4">
-    <div class="msg-box text-[#0f172a] p-6 rounded-xl shadow relative w-full max-w-lg h-96 overflow-y-auto">
-      <button id="msgClose" class="absolute top-2 right-2 text-2xl leading-none" aria-label="Close">×</button>
-      <h3 id="msgTitle" class="font-bold text-center mb-4"></h3>
-      <div id="msgText" class="whitespace-pre-line"></div>
-    </div>
+<div id="msgModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-[100] p-4">
+  <div class="msg-box text-[#0f172a] p-6 rounded-xl shadow relative w-full max-w-lg h-96 overflow-y-auto">
+    <button id="msgClose" class="absolute top-2 right-2 text-2xl leading-none" aria-label="Close">×</button>
+    <h3 id="msgTitle" class="font-bold text-center mb-4"></h3>
+    <div id="msgText" class="whitespace-pre-line"></div>
   </div>
+</div>
 
-  <section class="section"><div class="wrap"><h1 class="grad">Apply Online</h1><p class="muted">Application form coming soon.</p></div></section>
+<section class="section"><div class="wrap"><h1 class="grad">Governing Body</h1><p class="muted">Details coming soon.</p></div></section>
 
 <footer class="footer">
   <div class="wrap">

--- a/pages/notice.html
+++ b/pages/notice.html
@@ -25,6 +25,7 @@
         <a class="nav-btn" href="../index.html">Home</a>
         <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
         <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a><a href="governing.html">Governing Body</a></div></div></div>
         <a class="nav-btn" href="apply.html">Apply</a>
         <a id="loginNav" class="cta red" href="#login">Login</a>
       </nav>
@@ -50,6 +51,14 @@
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
         <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
         <a class="mlink" href="../index.html#gallery">Gallery</a>
+      </div>
+    </div>
+    <div class="mitem">
+      <button class="mhead">Administration</button>
+      <div class="msub">
+        <a class="mlink" href="teachers.html">Teachers</a>
+        <a class="mlink" href="staffs.html">Staffs</a>
+        <a class="mlink" href="governing.html">Governing Body</a>
       </div>
     </div>
     <a class="mlink" href="apply.html">Apply</a>

--- a/pages/staffs.html
+++ b/pages/staffs.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Apply Online - Ispahani Cantonment Public School & College</title>
+  <title>Staffs - Ispahani Cantonment Public School & College</title>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Bengali:wght@400;600;700&family=Inter:wght@500;700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
@@ -80,15 +80,15 @@
     </div>
   </div>
 </div>
-  <div id="msgModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-[100] p-4">
-    <div class="msg-box text-[#0f172a] p-6 rounded-xl shadow relative w-full max-w-lg h-96 overflow-y-auto">
-      <button id="msgClose" class="absolute top-2 right-2 text-2xl leading-none" aria-label="Close">×</button>
-      <h3 id="msgTitle" class="font-bold text-center mb-4"></h3>
-      <div id="msgText" class="whitespace-pre-line"></div>
-    </div>
+<div id="msgModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-[100] p-4">
+  <div class="msg-box text-[#0f172a] p-6 rounded-xl shadow relative w-full max-w-lg h-96 overflow-y-auto">
+    <button id="msgClose" class="absolute top-2 right-2 text-2xl leading-none" aria-label="Close">×</button>
+    <h3 id="msgTitle" class="font-bold text-center mb-4"></h3>
+    <div id="msgText" class="whitespace-pre-line"></div>
   </div>
+</div>
 
-  <section class="section"><div class="wrap"><h1 class="grad">Apply Online</h1><p class="muted">Application form coming soon.</p></div></section>
+<section class="section"><div class="wrap"><h1 class="grad">Staffs</h1><p class="muted">Details coming soon.</p></div></section>
 
 <footer class="footer">
   <div class="wrap">

--- a/pages/teachers.html
+++ b/pages/teachers.html
@@ -25,6 +25,7 @@
         <a class="nav-btn" href="../index.html">Home</a>
         <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
         <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a><a href="governing.html">Governing Body</a></div></div></div>
         <a class="nav-btn" href="apply.html">Apply</a>
         <a id="loginNav" class="cta red" href="#login">Login</a>
       </nav>
@@ -50,6 +51,14 @@
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
         <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
         <a class="mlink" href="../index.html#gallery">Gallery</a>
+      </div>
+    </div>
+    <div class="mitem">
+      <button class="mhead">Administration</button>
+      <div class="msub">
+        <a class="mlink" href="teachers.html">Teachers</a>
+        <a class="mlink" href="staffs.html">Staffs</a>
+        <a class="mlink" href="governing.html">Governing Body</a>
       </div>
     </div>
     <a class="mlink" href="apply.html">Apply</a>
@@ -79,7 +88,7 @@
     </div>
   </div>
 
-<section class="section"><div class="wrap"><h1 class="grad">Teachers</h1><div id="teachersAll" class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div><div id="teacherPagination" class="mt-6 flex justify-center gap-2"></div></div></section>
+<section class="section bg-gradient-to-br from-yellow-50 via-white to-green-50"><div class="wrap"><h1 class="grad">Teachers</h1><div id="teachersAll" class="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div><div id="teacherPagination" class="mt-6 flex justify-center gap-2"></div></div></section>
 
 <footer class="footer">
   <div class="wrap">


### PR DESCRIPTION
## Summary
- Make teacher cards magazine-styled with full details and click-through
- Add responsive limits to home-page teachers grid and fancy background on teachers page
- Introduce Administration menu with links to Teachers, Staffs, and Governing Body

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc61d00424832b9982d4aa6db29c37