### PR TITLE
Add circular leadership avatars with glow

### DIFF
--- a/components/common.css
+++ b/components/common.css
@@ -59,9 +59,10 @@
     .cards{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem}@media(max-width:900px){.cards{grid-template-columns:1fr}}.card{background:#fff;border:1px solid #e2e8f0;border-radius:1rem;padding:1rem;box-shadow:0 8px 16px rgba(2,6,23,.06)}.card.pop{transition:.2s}.card.pop:hover{transform:translateY(-3px);box-shadow:0 16px 32px rgba(2,6,23,.12)}.bul{margin:.3rem 0 0 1rem}
     .timeline{border-left:3px solid #e2e8f0;margin-left:1rem;display:grid;gap:1rem}.timeline li{position:relative;list-style:none}.timeline .dot{position:absolute;left:-9px;top:.6rem;width:14px;height:14px;background:var(--brand-red);border-radius:50%}.timeline .card{margin-left:.5rem}
     .leaders{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));justify-items:center;gap:1.5rem}
-    .leader{width:100%;max-width:360px;display:flex;flex-direction:column;background:linear-gradient(#fff,#fff) padding-box,linear-gradient(135deg,var(--brand-green),var(--brand-red)) border-box;border:2px solid transparent;border-radius:1.25rem;overflow:hidden;box-shadow:0 8px 20px rgba(2,6,23,.06);transition:transform .2s,box-shadow .2s}
+    .leader{width:100%;max-width:360px;position:relative;display:flex;flex-direction:column;align-items:center;text-align:center;background:linear-gradient(#fff,#fff) padding-box,linear-gradient(135deg,var(--brand-green),var(--brand-red)) border-box;border:2px solid transparent;border-radius:1.25rem;box-shadow:0 8px 20px rgba(2,6,23,.06);padding-top:4rem;overflow:visible;transition:transform .2s,box-shadow .2s}
     .leader:hover{transform:translateY(-4px);box-shadow:0 12px 24px rgba(2,6,23,.12)}
-    .leader img{width:100%;height:200px;object-fit:contain;display:block;background:#fff}
+    .leader .avatar{position:absolute;top:-3rem;left:50%;transform:translateX(-50%);width:6rem;height:6rem;border-radius:50%;overflow:hidden;box-shadow:0 0 0 4px #fff,0 0 20px rgba(20,83,45,.45)}
+    .leader .avatar img{width:100%;height:100%;object-fit:cover;display:block}
     .leader .info{padding:1rem;display:flex;flex-direction:column;align-items:center;text-align:center;gap:.5rem;flex:1}
     .leader .name{font-weight:700;font-size:1.1rem}
     .leader .chip{margin-top:.75rem;display:inline-flex;padding:.45rem .9rem;border-radius:.75rem;text-decoration:none;font-weight:700;justify-content:center;background:linear-gradient(135deg,#3b82f6,#9333ea);color:#fff}

--- a/index.html
+++ b/index.html
@@ -94,7 +94,25 @@
 <section id="notices" class="section"><div class="wrap"><div class="head"><h2>Notices</h2><a class="link" href="pages/notice.html">সব নোটিশ →</a></div><ol class="timeline"><li><div class="dot"></div><div class="card"><h3>একাদশ শ্রেণিতে ভর্তি বিজ্ঞপ্তি (২০২৫–২০২৬)</h3><p>নির্ধারিত সময়ের মধ্যে অনলাইনে আবেদন করুন। প্রয়োজনীয় কাগজপত্রের তালিকা PDF এ দেখুন।</p><a class="link" href="#">PDF</a></div></li><li><div class="dot"></div><div class="card"><h3>Model Test Routine — HSC</h3><p>আসন্ন মডেল টেস্টের রুটিন ডাউনলোড করুন।</p><a class="link" href="#">Download</a></div></li><li><div class="dot"></div><div class="card"><h3>Science Fair Registration</h3><p>ক্লাস ৬–১২: Robotics, IoT, AI, Green Energy.</p><a class="link" href="#">Register</a></div></li></ol></div></section>
   <div class="divider wave flip" aria-hidden="true"></div>
 
-<section id="leadership" class="section"><div class="wrap"><div class="head"><h2>Leadership</h2><span class="muted">Student messages from leadership</span></div><div class="leaders"><article class="leader" data-info="assets/leaders/leader-1.txt"><img loading="lazy" src="assets/leaders/leader-1.jpg" alt="Chief Patron"><div class="info"><h4>Chief Patron</h4><p class="name">Loading...</p><a class="chip" href="#">Read Message</a></div></article><article class="leader" data-info="assets/leaders/leader-2.txt"><img loading="lazy" src="assets/leaders/leader-2.jpg" alt="Chairman"><div class="info"><h4>Chairman</h4><p class="name">Loading...</p><a class="chip" href="#">Read Message</a></div></article><article class="leader" data-info="assets/leaders/leader-3.txt"><img loading="lazy" src="assets/leaders/leader-3.jpg" alt="Principal"><div class="info"><h4>Principal</h4><p class="name">Loading...</p><a class="chip" href="#">Read Message</a></div></article></div></div></section>
+<section id="leadership" class="section">
+  <div class="wrap">
+    <div class="head"><h2>Leadership</h2><span class="muted">Student messages from leadership</span></div>
+    <div class="leaders">
+      <article class="leader" data-info="assets/leaders/leader-1.txt">
+        <div class="avatar"><img loading="lazy" src="assets/leaders/leader-1.jpg" alt="Chief Patron"></div>
+        <div class="info"><h4>Chief Patron</h4><p class="name">Loading...</p><a class="chip" href="#">Read Message</a></div>
+      </article>
+      <article class="leader" data-info="assets/leaders/leader-2.txt">
+        <div class="avatar"><img loading="lazy" src="assets/leaders/leader-2.jpg" alt="Chairman"></div>
+        <div class="info"><h4>Chairman</h4><p class="name">Loading...</p><a class="chip" href="#">Read Message</a></div>
+      </article>
+      <article class="leader" data-info="assets/leaders/leader-3.txt">
+        <div class="avatar"><img loading="lazy" src="assets/leaders/leader-3.jpg" alt="Principal"></div>
+        <div class="info"><h4>Principal</h4><p class="name">Loading...</p><a class="chip" href="#">Read Message</a></div>
+      </article>
+    </div>
+  </div>
+</section>
   <div class="divider wave" aria-hidden="true"></div>
 
   <section id="achievements" class="section"><div class="wrap"><div class="head"><h2>Achievements</h2><span class="muted">Be a Champion</span></div><div class="counters"><div class="counter"><span data-count="38">0</span><label>Competition Trophies</label></div><div class="counter"><span data-count="12">0</span><label>Active Clubs</label></div><div class="counter"><span data-count="120">0</span><label>Total Teachers</label></div></div><div class="mt-6 flex flex-col md:flex-row items-center gap-6"><img loading="lazy" class="rounded-xl shadow" src="assets/achievement-placeholder.png" alt="Champion team"></div></div></section>


### PR DESCRIPTION
## Summary
- Restyle leadership cards with circular avatars that sit halfway outside their boxes
- Add glowing ring effect and adjust card layout for better presentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc899287e4832b98ce60c2ffc24133