### PR TITLE
Improve leadership card spacing and avatar size

### DIFF
--- a/components/common.css
+++ b/components/common.css
@@ -58,10 +58,10 @@
     #msgModal.open .msg-box{transform:scale(1)}
     .cards{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem}@media(max-width:900px){.cards{grid-template-columns:1fr}}.card{background:#fff;border:1px solid #e2e8f0;border-radius:1rem;padding:1rem;box-shadow:0 8px 16px rgba(2,6,23,.06)}.card.pop{transition:.2s}.card.pop:hover{transform:translateY(-3px);box-shadow:0 16px 32px rgba(2,6,23,.12)}.bul{margin:.3rem 0 0 1rem}
     .timeline{border-left:3px solid #e2e8f0;margin-left:1rem;display:grid;gap:1rem}.timeline li{position:relative;list-style:none}.timeline .dot{position:absolute;left:-9px;top:.6rem;width:14px;height:14px;background:var(--brand-red);border-radius:50%}.timeline .card{margin-left:.5rem}
-    .leaders{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));justify-items:center;gap:5rem 2rem}
-    .leader{width:100%;max-width:380px;position:relative;display:flex;flex-direction:column;align-items:center;text-align:center;background:linear-gradient(#fff,#fff) padding-box,linear-gradient(135deg,var(--brand-green),var(--brand-red)) border-box;border:2px solid transparent;border-radius:1.25rem;box-shadow:0 8px 20px rgba(2,6,23,.06);padding-top:5rem;overflow:visible;transition:transform .2s,box-shadow .2s}
+    .leaders{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));justify-items:center;gap:5rem 2rem;margin-top:5rem}
+    .leader{width:100%;max-width:360px;position:relative;display:flex;flex-direction:column;align-items:center;text-align:center;background:linear-gradient(#fff,#fff) padding-box,linear-gradient(135deg,var(--brand-green),var(--brand-red)) border-box;border:2px solid transparent;border-radius:1.25rem;box-shadow:0 8px 20px rgba(2,6,23,.06);padding-top:6rem;overflow:visible;transition:transform .2s,box-shadow .2s}
     .leader:hover{transform:translateY(-4px);box-shadow:0 12px 24px rgba(2,6,23,.12)}
-    .leader .avatar{position:absolute;top:-3.5rem;left:50%;transform:translateX(-50%);width:7rem;height:7rem;border-radius:50%;overflow:hidden;box-shadow:0 0 0 4px #fff,0 0 20px rgba(20,83,45,.45)}
+    .leader .avatar{position:absolute;top:-4.5rem;left:50%;transform:translateX(-50%);width:9rem;height:9rem;border-radius:50%;overflow:hidden;box-shadow:0 0 0 4px #fff,0 0 20px rgba(20,83,45,.45)}
     .leader .avatar img{width:100%;height:100%;object-fit:cover;display:block}
     .leader .info{padding:1rem;display:flex;flex-direction:column;align-items:center;text-align:center;gap:.5rem;flex:1}
     .leader .name{font-weight:700;font-size:1.1rem}


### PR DESCRIPTION
## Summary
- prevent leadership cards from overlapping the section headline
- enlarge leader portrait and tweak card width for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8e7078dc832b8cd60dc09ef810d9