### PR TITLE
Add navigation icons and refine dropdown panel styling

### DIFF
--- a/components/common.css
+++ b/components/common.css
@@ -33,7 +33,7 @@
     .mob .msub.open{display:flex}
     .mob .msub .mlink{padding:.5rem 1.5rem;border-top:1px solid #e2e8f0;font-weight:600}
     .mega{position:relative}
-    .mega .panel{position:absolute;left:50%;top:100%;transform:translateX(-50%);width:min(320px,92vw);background:#fff;border:1px solid #e2e8f0;border-radius:1rem;box-shadow:0 24px 60px rgba(2,6,23,.15);padding:1rem;display:none;grid-template-columns:1fr;gap:.5rem;z-index:50}
+    .mega .panel{position:absolute;left:50%;top:100%;transform:translateX(-50%);width:min(320px,92vw);background:#fff;backdrop-filter:none;opacity:1;border:1px solid #e2e8f0;border-radius:1rem;box-shadow:0 24px 60px rgba(2,6,23,.15);padding:1rem;display:none;grid-template-columns:1fr;gap:.5rem;z-index:50}
     .mega .panel .col{display:flex;flex-direction:column}
     .mega .panel .col+ .col{border-top:1px solid #e2e8f0;padding-top:.5rem;margin-top:.5rem}
     .mega .panel .col h4{font-weight:800;font-size:.85rem;margin-bottom:.3rem}
@@ -46,7 +46,7 @@
     .ticker-track{display:flex;gap:2rem;white-space:nowrap;animation:t 26s linear infinite}
     .ticker:hover .ticker-track{animation-play-state:paused}
     .tick{color:#ffe4e6;text-decoration:none;padding:.5rem 0}
-    #masthead.menu-open .ticker{pointer-events:none}
+    #masthead.menu-open .ticker{pointer-events:none;opacity:0}
     @keyframes t{from{transform:translateX(0)}to{transform:translateX(-50%)}}
     .section{padding:2.2rem 0}.head{display:flex;align-items:center;justify-content:space-between;gap:1rem;margin:.8rem 0}.head h2{font-size:1.6rem;font-weight:900}.head .title{display:flex;align-items:center;gap:.5rem}.muted{color:#64748b}.section-tag{display:inline-block;font-size:.75rem;font-weight:800;color:var(--brand-red);background:#fee2e2;border:1px solid #fecaca;border-radius:.5rem;padding:.15rem .5rem}.welcome-tag{display:block;margin:0 auto;text-align:center;font-size:1.5rem}
     .display{font-size:clamp(1rem,5vw,3rem);font-weight:900;letter-spacing:-.02em}.grad{background:linear-gradient(120deg,var(--brand-red),var(--brand-green));-webkit-background-clip:text;color:transparent}.lede{margin-top:.6rem;color:#475569;max-width:58ch}.btns{margin-top:1rem;display:flex;gap:.6rem;flex-wrap:wrap;justify-content:center}

--- a/index.html
+++ b/index.html
@@ -22,47 +22,47 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="#houses">Houses</a><a href="#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="#resources">Syllabus (PDF)</a><a href="#resources">Question Bank</a><a href="#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="#facilities">Labs & Library</a><a href="#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="pages/clubs.html">Clubs & Societies</a><a href="#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="pages/teachers.html">Teachers</a><a href="pages/staffs.html">Staffs</a><a href="pages/governing.html">Governing Body</a></div></div></div>
-        <a class="nav-btn" href="pages/apply.html">Apply</a>
-        <a id="loginNav" class="cta red" href="#login">Login</a>
+        <a class="nav-btn" href="index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="pages/clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="pages/teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="pages/staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a><a href="pages/governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a></div></div></div>
+        <a class="nav-btn" href="pages/apply.html"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
+        <a id="loginNav" class="cta red" href="#login"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="index.html">Home</a>
+    <a class="mlink" href="index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
       <div class="msub">
-        <a class="mlink" href="#houses">Houses</a>
-        <a class="mlink" href="#classes">Classes</a>
-        <a class="mlink" href="#resources">Syllabus (PDF)</a>
-        <a class="mlink" href="#resources">Question Bank</a>
-        <a class="mlink" href="#resources">e-Library</a>
+        <a class="mlink" href="#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
+        <a class="mlink" href="#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
+        <a class="mlink" href="#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
+        <a class="mlink" href="#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
+        <a class="mlink" href="#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
       <div class="msub">
-        <a class="mlink" href="#facilities">Labs &amp; Library</a>
-        <a class="mlink" href="#facilities">Playgrounds</a>
-        <a class="mlink" href="pages/clubs.html">Clubs &amp; Societies</a>
-        <a class="mlink" href="#gallery">Gallery</a>
+        <a class="mlink" href="#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
+        <a class="mlink" href="#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
+        <a class="mlink" href="pages/clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
+        <a class="mlink" href="#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
       <div class="msub">
-        <a class="mlink" href="pages/teachers.html">Teachers</a>
-        <a class="mlink" href="pages/staffs.html">Staffs</a>
-        <a class="mlink" href="pages/governing.html">Governing Body</a>
+        <a class="mlink" href="pages/teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
+        <a class="mlink" href="pages/staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="pages/governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
       </div>
     </div>
-    <a class="mlink" href="pages/apply.html">Apply</a>
-    <a id="loginNavM" class="mlink special" href="#login">Login</a>
+    <a class="mlink" href="pages/apply.html"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
+    <a id="loginNavM" class="mlink special" href="#login"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -22,47 +22,47 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a><a href="governing.html">Governing Body</a></div></div></div>
-        <a class="nav-btn" href="apply.html">Apply</a>
-        <a id="loginNav" class="cta red" href="#login">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a></div></div></div>
+        <a class="nav-btn" href="apply.html"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
+        <a id="loginNav" class="cta red" href="#login"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses">Houses</a>
-        <a class="mlink" href="../index.html#classes">Classes</a>
-        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources">Question Bank</a>
-        <a class="mlink" href="../index.html#resources">e-Library</a>
+        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
+        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
-        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery">Gallery</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
+        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
       <div class="msub">
-        <a class="mlink" href="teachers.html">Teachers</a>
-        <a class="mlink" href="staffs.html">Staffs</a>
-        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
+        <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
       </div>
     </div>
-    <a class="mlink" href="apply.html">Apply</a>
-    <a id="loginNavM" class="mlink special" href="#login">Login</a>
+    <a class="mlink" href="apply.html"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
+    <a id="loginNavM" class="mlink special" href="#login"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/pages/clubs.html
+++ b/pages/clubs.html
@@ -22,47 +22,47 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a><a href="governing.html">Governing Body</a></div></div></div>
-        <a class="nav-btn" href="apply.html">Apply</a>
-        <a id="loginNav" class="cta red" href="#login">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a></div></div></div>
+        <a class="nav-btn" href="apply.html"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
+        <a id="loginNav" class="cta red" href="#login"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses">Houses</a>
-        <a class="mlink" href="../index.html#classes">Classes</a>
-        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources">Question Bank</a>
-        <a class="mlink" href="../index.html#resources">e-Library</a>
+        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
+        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
-        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery">Gallery</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
+        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
       <div class="msub">
-        <a class="mlink" href="teachers.html">Teachers</a>
-        <a class="mlink" href="staffs.html">Staffs</a>
-        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
+        <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
       </div>
     </div>
-    <a class="mlink" href="apply.html">Apply</a>
-    <a id="loginNavM" class="mlink special" href="#login">Login</a>
+    <a class="mlink" href="apply.html"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
+    <a id="loginNavM" class="mlink special" href="#login"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/pages/governing.html
+++ b/pages/governing.html
@@ -22,47 +22,47 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a><a href="governing.html">Governing Body</a></div></div></div>
-        <a class="nav-btn" href="apply.html">Apply</a>
-        <a id="loginNav" class="cta red" href="#login">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a></div></div></div>
+        <a class="nav-btn" href="apply.html"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
+        <a id="loginNav" class="cta red" href="#login"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses">Houses</a>
-        <a class="mlink" href="../index.html#classes">Classes</a>
-        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources">Question Bank</a>
-        <a class="mlink" href="../index.html#resources">e-Library</a>
+        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
+        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
-        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery">Gallery</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
+        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
       <div class="msub">
-        <a class="mlink" href="teachers.html">Teachers</a>
-        <a class="mlink" href="staffs.html">Staffs</a>
-        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
+        <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
       </div>
     </div>
-    <a class="mlink" href="apply.html">Apply</a>
-    <a id="loginNavM" class="mlink special" href="#login">Login</a>
+    <a class="mlink" href="apply.html"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
+    <a id="loginNavM" class="mlink special" href="#login"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/pages/notice.html
+++ b/pages/notice.html
@@ -22,47 +22,47 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a><a href="governing.html">Governing Body</a></div></div></div>
-        <a class="nav-btn" href="apply.html">Apply</a>
-        <a id="loginNav" class="cta red" href="#login">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a></div></div></div>
+        <a class="nav-btn" href="apply.html"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
+        <a id="loginNav" class="cta red" href="#login"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses">Houses</a>
-        <a class="mlink" href="../index.html#classes">Classes</a>
-        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources">Question Bank</a>
-        <a class="mlink" href="../index.html#resources">e-Library</a>
+        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
+        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
-        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery">Gallery</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
+        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
       <div class="msub">
-        <a class="mlink" href="teachers.html">Teachers</a>
-        <a class="mlink" href="staffs.html">Staffs</a>
-        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
+        <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
       </div>
     </div>
-    <a class="mlink" href="apply.html">Apply</a>
-    <a id="loginNavM" class="mlink special" href="#login">Login</a>
+    <a class="mlink" href="apply.html"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
+    <a id="loginNavM" class="mlink special" href="#login"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/pages/staffs.html
+++ b/pages/staffs.html
@@ -22,47 +22,47 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a><a href="governing.html">Governing Body</a></div></div></div>
-        <a class="nav-btn" href="apply.html">Apply</a>
-        <a id="loginNav" class="cta red" href="#login">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a></div></div></div>
+        <a class="nav-btn" href="apply.html"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
+        <a id="loginNav" class="cta red" href="#login"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses">Houses</a>
-        <a class="mlink" href="../index.html#classes">Classes</a>
-        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources">Question Bank</a>
-        <a class="mlink" href="../index.html#resources">e-Library</a>
+        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
+        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
-        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery">Gallery</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
+        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
       <div class="msub">
-        <a class="mlink" href="teachers.html">Teachers</a>
-        <a class="mlink" href="staffs.html">Staffs</a>
-        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
+        <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
       </div>
     </div>
-    <a class="mlink" href="apply.html">Apply</a>
-    <a id="loginNavM" class="mlink special" href="#login">Login</a>
+    <a class="mlink" href="apply.html"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
+    <a id="loginNavM" class="mlink special" href="#login"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/pages/teachers.html
+++ b/pages/teachers.html
@@ -22,47 +22,47 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a><a href="governing.html">Governing Body</a></div></div></div>
-        <a class="nav-btn" href="apply.html">Apply</a>
-        <a id="loginNav" class="cta red" href="#login">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a></div></div></div>
+        <a class="nav-btn" href="apply.html"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
+        <a id="loginNav" class="cta red" href="#login"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses">Houses</a>
-        <a class="mlink" href="../index.html#classes">Classes</a>
-        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources">Question Bank</a>
-        <a class="mlink" href="../index.html#resources">e-Library</a>
+        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
+        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
+        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
-        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery">Gallery</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
+        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
       <div class="msub">
-        <a class="mlink" href="teachers.html">Teachers</a>
-        <a class="mlink" href="staffs.html">Staffs</a>
-        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
+        <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
       </div>
     </div>
-    <a class="mlink" href="apply.html">Apply</a>
-    <a id="loginNavM" class="mlink special" href="#login">Login</a>
+    <a class="mlink" href="apply.html"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
+    <a id="loginNavM" class="mlink special" href="#login"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>


### PR DESCRIPTION
## Summary
- Add Font Awesome icons to desktop and mobile navigation links with matching icons for dropdown items
- Make dropdown panels fully opaque and hide ticker when menus open to avoid notice bar showing through

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc4ecacc8832bac6fccbdbc9e86f0