### PR TITLE
Remove background images and refine text styles

### DIFF
--- a/components/common.css
+++ b/components/common.css
@@ -49,7 +49,7 @@
     #masthead.menu-open .ticker{pointer-events:none;opacity:0}
     @keyframes t{from{transform:translateX(0)}to{transform:translateX(-50%)}}
     .section{padding:2.2rem 0}.head{display:flex;align-items:center;justify-content:space-between;gap:1rem;margin:.8rem 0}.head h2{font-size:1.6rem;font-weight:900}.head .title{display:flex;align-items:center;gap:.5rem}.muted{color:#64748b}.section-tag{display:inline-block;font-size:.75rem;font-weight:800;color:var(--brand-red);background:#fee2e2;border:1px solid #fecaca;border-radius:.5rem;padding:.15rem .5rem}.welcome-tag{display:block;margin:0 auto;text-align:center;font-size:1.5rem}
-    .display{font-size:clamp(1rem,5vw,3rem);font-weight:900;letter-spacing:-.02em}.grad{background:linear-gradient(120deg,var(--brand-red),var(--brand-green));-webkit-background-clip:text;color:transparent}.lede{margin-top:.6rem;color:#475569;max-width:58ch}.btns{margin-top:1rem;display:flex;gap:.6rem;flex-wrap:wrap;justify-content:center}
+    .display{font-size:clamp(1rem,5vw,3rem);font-weight:900;letter-spacing:-.02em}.grad{background:linear-gradient(120deg,#f87171,#4ade80);-webkit-background-clip:text;color:transparent}.lede{margin-top:.6rem;color:#475569;max-width:58ch}.btns{margin-top:1rem;display:flex;gap:.6rem;flex-wrap:wrap;justify-content:center}
     .hero{position:relative;overflow:hidden;isolation:isolate;padding:3rem 0}
     .hero::before{content:"";position:absolute;inset:0;background:url('../assets/background.png') center/cover no-repeat;opacity:.25;mix-blend-mode:multiply;pointer-events:none}
     #msgModal{opacity:0;pointer-events:none;transition:opacity .3s}
@@ -78,6 +78,7 @@
     #decor{position:fixed;top:0;left:50%;transform:translateX(-50%);width:100%;max-width:1200px;height:100%;pointer-events:none;overflow:hidden;z-index:0}
     .shape{position:absolute;width:80px;height:80px;opacity:.12;animation:drift 30s linear infinite}
     .shape.circle{border-radius:50%;background:radial-gradient(circle,var(--brand-green),var(--brand-red))}
+    .staff-card h4,.staff-card p,.teacher-card h4,.teacher-card p{word-break:break-word;overflow-wrap:anywhere}
     .shape.square{background:linear-gradient(135deg,var(--brand-red),#fff)}
     .shape.triangle{background:linear-gradient(135deg,#fff,var(--brand-green));clip-path:polygon(50% 0,0 100%,100% 100%)}
     @keyframes drift{from{transform:translateY(0) rotate(0deg)}to{transform:translateY(-40px) rotate(360deg)}}

--- a/pages/staffs.html
+++ b/pages/staffs.html
@@ -88,7 +88,7 @@
   </div>
 </div>
 
-<section class="section" style="background-image:url('../assets/background.png');background-size:cover;background-repeat:no-repeat;">
+<section class="section">
   <div class="wrap">
     <div class="text-center mb-8">
       <h1 class="grad text-4xl font-extrabold">নীরব সহযোদ্ধাদের প্রতি কৃতজ্ঞতা</h1>

--- a/pages/teachers.html
+++ b/pages/teachers.html
@@ -88,7 +88,7 @@
     </div>
   </div>
 
-<section class="section" style="background-image:url('../assets/teachers/paint-bg.jpg');background-size:cover;background-repeat:no-repeat">
+<section class="section">
   <div class="wrap">
     <div class="text-center mb-8">
       <h1 class="grad text-4xl font-extrabold">শ্রদ্ধেয় শিক্ষকবৃন্দের প্রতি অশেষ কৃতজ্ঞতা</h1>


### PR DESCRIPTION
## Summary
- Drop photo backdrops from staff and teacher sections for cleaner design
- Brighten gradient text and ensure card text wraps inside its box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd105c0df0832b96e91b6d726f4f30