### PR TITLE
Add login pages and role-based dashboards

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import driverRoutes from "./modules/drivers/routes";
 import officerRoutes from "./modules/officers/routes";
 import applicationRoutes from "./modules/applications/routes";
 import registrationRoutes from "./modules/registrations/routes";
+import dashboardRoutes from "./modules/dashboard/routes";
 
 connect();
 
@@ -39,6 +40,7 @@ app.use("/api/drivers", driverRoutes);
 app.use("/api/officers", officerRoutes);
 app.use("/api/applications", applicationRoutes);
 app.use("/api/registrations", registrationRoutes);
+app.use("/api/dashboard", dashboardRoutes);
 
 app.listen(process.env.PORT || 3000, () => {
   console.log("Server running");

--- a/backend/src/modules/dashboard/controller.ts
+++ b/backend/src/modules/dashboard/controller.ts
@@ -1,0 +1,10 @@
+import { Response } from "express";
+import { AuthRequest } from "../../middleware/auth";
+
+export function userDashboard(req: AuthRequest, res: Response) {
+  res.json({ message: `User dashboard for ${req.user?.role}` });
+}
+
+export function adminDashboard(req: AuthRequest, res: Response) {
+  res.json({ message: "Admin dashboard" });
+}

--- a/backend/src/modules/dashboard/routes.ts
+++ b/backend/src/modules/dashboard/routes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { userDashboard, adminDashboard } from "./controller";
+import { requireAuth } from "../../middleware/auth";
+import { authorize } from "../../middleware/authorize";
+import { Roles } from "../../constants/roles";
+
+const router = Router();
+
+router.get("/user", requireAuth, userDashboard);
+router.get("/admin", requireAuth, authorize([Roles.ADMIN]), adminDashboard);
+
+export default router;

--- a/frontend/pages/admin-dashboard.html
+++ b/frontend/pages/admin-dashboard.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-2xl mb-4">Admin Dashboard</h1>
+  <div id="content"></div>
+  <script>
+    async function load() {
+      const token = localStorage.getItem('token');
+      if (!token) { window.location.href = 'login.html'; return; }
+      const res = await fetch('/api/dashboard/admin', {
+        headers: { 'Authorization': 'Bearer ' + token }
+      });
+      const data = await res.json();
+      if (res.ok) {
+        document.getElementById('content').textContent = data.message;
+      } else {
+        alert('Unauthorized');
+        window.location.href = 'login.html';
+      }
+    }
+    load();
+  </script>
+</body>
+</html>

--- a/frontend/pages/login.html
+++ b/frontend/pages/login.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Login</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-2xl mb-4">Login</h1>
+  <form id="loginForm" class="space-y-4 max-w-sm">
+    <input id="username" type="text" placeholder="Username" class="w-full border p-2" />
+    <input id="password" type="password" placeholder="Password" class="w-full border p-2" />
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2">Login</button>
+  </form>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        localStorage.setItem('token', data.token);
+        const payload = JSON.parse(atob(data.token.split('.')[1]));
+        if (payload.role === 'admin') {
+          window.location.href = 'admin-dashboard.html';
+        } else {
+          window.location.href = 'user-dashboard.html';
+        }
+      } else {
+        alert(data.message || 'Login failed');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/frontend/pages/user-dashboard.html
+++ b/frontend/pages/user-dashboard.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>User Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-2xl mb-4">User Dashboard</h1>
+  <div id="content"></div>
+  <script>
+    async function load() {
+      const token = localStorage.getItem('token');
+      if (!token) { window.location.href = 'login.html'; return; }
+      const res = await fetch('/api/dashboard/user', {
+        headers: { 'Authorization': 'Bearer ' + token }
+      });
+      const data = await res.json();
+      if (res.ok) {
+        document.getElementById('content').textContent = data.message;
+      } else {
+        alert('Unauthorized');
+        window.location.href = 'login.html';
+      }
+    }
+    load();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add dashboard module with endpoints for users and admins
- Create simple frontend login page and dashboards for admin and regular users

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdaae8ace0832b87ee974bdc984e39