### PR TITLE
feat: add admin login flow and user management

### DIFF
--- a/backend/src/modules/users/service.ts
+++ b/backend/src/modules/users/service.ts
@@ -1,4 +1,4 @@
-import { Role } from "../../constants/roles";
+import { Role, Roles } from "../../constants/roles";
 
 export interface User {
   id: number;
@@ -7,7 +7,15 @@ export interface User {
   role: Role;
 }
 
-const users: User[] = [];
+const users: User[] = [
+  {
+    id: 1,
+    username: "admin",
+    // password: "admin"
+    password: "$2b$10$0TnDNFY.41ItaoE0yCji5u3Gdi2CsDSBG2hIUT6ztGUVSXmtRbNd.",
+    role: Roles.ADMIN,
+  },
+];
 
 export function addUser(data: Omit<User, "id">): User {
   const user: User = { id: users.length + 1, ...data };

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -225,9 +225,10 @@ function initCommon(){
   const io2=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){gsap.to(e.target,{opacity:1,y:0,duration:.6});io2.unobserve(e.target);}})},{threshold:.2});
   revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});
   const loginModal=document.getElementById('loginModal'),loginNav=document.getElementById('loginNav'),loginNavM=document.getElementById('loginNavM'),loginOk=document.getElementById('loginOk'),loginCancel=document.getElementById('loginCancel');
-  function openLogin(e){e.preventDefault();loginModal.classList.remove('hidden');}
+  const loginUrl=window.location.pathname.includes('/pages/')?'login.html':'pages/login.html';
+  function openLogin(e){e.preventDefault();window.location.href=loginUrl;}
   if(loginNav) loginNav.addEventListener('click',openLogin);
-    if(loginNavM) loginNavM.addEventListener('click',e=>{openLogin(e);if(mobileNav) mobileNav.classList.add('hidden');updateMast();});
-  if(loginCancel) loginCancel.addEventListener('click',()=>loginModal.classList.add('hidden'));
-  if(loginOk) loginOk.addEventListener('click',()=>loginModal.classList.add('hidden'));
+  if(loginNavM) loginNavM.addEventListener('click',e=>{openLogin(e);if(mobileNav) mobileNav.classList.add('hidden');updateMast();});
+  if(loginCancel) loginCancel.addEventListener('click',()=>loginModal&&loginModal.classList.add('hidden'));
+  if(loginOk) loginOk.addEventListener('click',()=>loginModal&&loginModal.classList.add('hidden'));
 }

--- a/frontend/pages/admin-dashboard.html
+++ b/frontend/pages/admin-dashboard.html
@@ -8,6 +8,9 @@
 </head>
 <body class="p-4">
   <h1 class="text-2xl mb-4">Admin Dashboard</h1>
+  <div class="mb-4">
+    <a href="create-user.html" class="bg-green-600 text-white px-4 py-2">Create User</a>
+  </div>
   <div id="content"></div>
   <script>
     async function load() {

--- a/frontend/pages/create-user.html
+++ b/frontend/pages/create-user.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Create User</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-2xl mb-4">Create User</h1>
+  <form id="createForm" class="space-y-4 max-w-sm">
+    <input id="username" type="text" placeholder="Username" class="w-full border p-2" />
+    <input id="password" type="password" placeholder="Password" class="w-full border p-2" />
+    <select id="role" class="w-full border p-2">
+      <option value="student">Student</option>
+      <option value="teacher">Teacher</option>
+      <option value="librarian">Librarian</option>
+      <option value="staff">Staff</option>
+      <option value="driver">Driver</option>
+      <option value="officer">Officer</option>
+      <option value="admin">Admin</option>
+    </select>
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2">Create</button>
+  </form>
+  <script>
+    document.getElementById('createForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const token = localStorage.getItem('token');
+      if (!token) { window.location.href = 'login.html'; return; }
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      const role = document.getElementById('role').value;
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + token
+        },
+        body: JSON.stringify({ username, password, role })
+      });
+      if (res.ok) {
+        alert('User created');
+        window.location.href = 'admin-dashboard.html';
+      } else {
+        const data = await res.json().catch(() => ({}));
+        alert(data.message || 'Failed to create user');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- seed default admin user
- route nav login to dedicated page
- allow admin to create users via new page

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb26ea600832b8fd7d8fd4e21975a