### PR TITLE
Serve frontend from backend

### DIFF
--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = __importDefault(require("express"));
 const cors_1 = __importDefault(require("cors"));
 const helmet_1 = __importDefault(require("helmet"));
+const path_1 = __importDefault(require("path"));
 const db_1 = __importDefault(require("./config/db"));
 const routes_1 = __importDefault(require("./modules/auth/routes"));
 const routes_2 = __importDefault(require("./modules/students/routes"));
@@ -42,6 +43,9 @@ app.use("/api/officers", routes_12.default);
 app.use("/api/applications", routes_13.default);
 app.use("/api/registrations", routes_14.default);
 app.use("/api/dashboard", routes_15.default);
+// Serve frontend static files
+const frontendDir = path_1.default.join(__dirname, "../../frontend");
+app.use(express_1.default.static(frontendDir));
 app.listen(process.env.PORT || 3000, () => {
     console.log("Server running");
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import helmet from "helmet";
+import path from "path";
 import connect from "./config/db";
 
 import authRoutes from "./modules/auth/routes";
@@ -41,6 +42,10 @@ app.use("/api/officers", officerRoutes);
 app.use("/api/applications", applicationRoutes);
 app.use("/api/registrations", registrationRoutes);
 app.use("/api/dashboard", dashboardRoutes);
+
+// Serve frontend static files
+const frontendDir = path.join(__dirname, "../../frontend");
+app.use(express.static(frontendDir));
 
 app.listen(process.env.PORT || 3000, () => {
   console.log("Server running");


### PR DESCRIPTION
## Summary
- Serve the frontend folder via Express so root URL shows the site
- Include path module and static middleware for compiled server

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb900df18832b9cbcebaf3d7cc7c1