### PR TITLE
Ensure student videos display in framed layout

### DIFF
--- a/frontend/assets/student-galleries/videos.json
+++ b/frontend/assets/student-galleries/videos.json
@@ -1,3 +1,4 @@
 [
+  "video1.mp4",
   "video2.mp4"
 ]

--- a/frontend/components/student-galleries.js
+++ b/frontend/components/student-galleries.js
@@ -41,7 +41,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const pauseOthers = cur => {
       wrap.querySelectorAll('video').forEach(v => {
-        if (v !== cur) v.pause();
+        if (v !== cur) {
+          v.pause();
+          v.muted = true;
+        }
       });
     };
 
@@ -49,10 +52,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       entries.forEach(e => {
         if (autoPlay) {
           if (e.isIntersecting) {
+            e.target.muted = false;
             e.target.play().catch(() => {});
             pauseOthers(e.target);
           } else {
             e.target.pause();
+            e.target.muted = true;
           }
         } else if (!e.isIntersecting) {
           e.target.pause();
@@ -63,7 +68,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     files.forEach(f => {
       const card = document.createElement(linkTarget ? 'a' : 'div');
       if (linkTarget) card.href = linkTarget;
-      card.className = 'mb-4 break-inside-avoid overflow-hidden rounded-lg shadow transition-shadow hover:shadow-lg';
+      card.className = 'mb-4 break-inside-avoid overflow-hidden rounded-lg shadow border border-gray-300 transition-shadow hover:shadow-lg';
 
       const video = document.createElement('video');
       video.src = root + 'assets/student-galleries/' + f;
@@ -71,7 +76,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       video.playsInline = true;
       video.muted = autoPlay;
       video.controls = !autoPlay;
-      video.className = 'w-full h-full';
+      video.className = 'w-full h-full object-contain';
 
       video.addEventListener('play', () => pauseOthers(video));
       video.addEventListener('loadedmetadata', () => {


### PR DESCRIPTION
## Summary
- display student gallery videos inside bordered frames that respect each video's aspect ratio
- list all available videos in JSON so gallery works consistently on desktop and mobile
- play video audio while scrolling past the student preview on the homepage and mute others

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd0dac448832ba00d747a15eb0fd0