### PR TITLE
fix: prevent student video cropping

### DIFF
--- a/frontend/components/student-galleries.js
+++ b/frontend/components/student-galleries.js
@@ -100,7 +100,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       video.autoplay = autoPlay;
       video.loop = true;
       video.controls = true;
-      video.className = 'w-full h-full object-cover';
+      video.className = 'w-full h-full object-contain object-center';
 
       video.addEventListener('play', () => pauseOthers(video));
 


### PR DESCRIPTION
## Summary
- show student videos fully inside frames by using `object-contain`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf015fc400832bb668554298100d82