### PR TITLE
Enable unmuted autoplay for student gallery

### DIFF
--- a/frontend/components/student-galleries.js
+++ b/frontend/components/student-galleries.js
@@ -81,6 +81,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             pauseOthers(e.target);
           } else {
             e.target.pause();
+            e.target.muted = true;
           }
         } else if (!e.isIntersecting) {
           e.target.pause();
@@ -90,7 +91,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     files.forEach(f => {
       const card = document.createElement('div');
-      card.className = 'video-card aspect-video overflow-hidden rounded-lg shadow border border-gray-300 transition-shadow hover:shadow-lg bg-black';
+      card.className = 'video-card aspect-video overflow-hidden rounded-xl shadow-lg border border-gray-200 transition-transform hover:-translate-y-1 hover:shadow-2xl bg-black';
 
       const video = document.createElement('video');
       video.src = root + 'assets/student-galleries/' + f;
@@ -102,7 +103,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       video.controls = true;
       video.className = 'w-full h-full object-contain object-center';
 
-      video.addEventListener('play', () => pauseOthers(video));
+      video.addEventListener('play', () => {
+        video.muted = false;
+        pauseOthers(video);
+      });
 
       io.observe(video);
       card.appendChild(video);

--- a/frontend/pages/student-galleries.html
+++ b/frontend/pages/student-galleries.html
@@ -82,7 +82,7 @@
       <h1 class="grad text-4xl font-extrabold leading-tight">শিক্ষার্থীদের সৃজনশীল নিবেদন</h1>
       <p class="mt-2 text-lg text-gray-700">স্কুল নিয়ে তৈরি তাদের ভিডিওগুলোর এই প্রচেষ্টাকে আমরা সম্মান জানাই।</p>
     </div>
-    <div id="studentGallery" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"></div>
+    <div id="studentGallery" data-autoplay="true" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"></div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Allow student gallery videos to start unmuted while pausing other clips.
- Mute videos when out of view and refine card styling for a classy hover effect.
- Enable autoplay on the student galleries page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf02838524832bb35ee0c6e8f19e40