### PR TITLE
feat: add interactive background

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -15,7 +15,7 @@
     .btext strong{display:block;font-weight:900}
     .btext span{display:block;font-size:.78rem;color:#64748b}
     .controls{display:flex;align-items:center;gap:.5rem;flex-shrink:0}
-    .nav{display:none;gap:.25rem;align-items:center;flex:1;justify-content:flex-end}@media(min-width:768px){.nav{display:flex}}.nav-btn{padding:.4rem .6rem;border-radius:.75rem;font-weight:600}
+    .nav{display:none;gap:.25rem;align-items:center;flex:1;justify-content:flex-end}@media(min-width:768px){.nav{display:flex}}.nav-btn{padding:.35rem .6rem;border-radius:.75rem;font-weight:500;font-size:.95rem}
     .nav-btn.icon{padding:.5rem;font-size:1.25rem;line-height:1}
     .mega>.nav-btn::after{content:"\25BE";margin-left:.25rem;font-size:.65em;display:inline-block;transition:transform .2s}
     .mega.open>.nav-btn::after{transform:rotate(180deg)}
@@ -23,15 +23,15 @@
     .cta.green{background:linear-gradient(135deg,var(--brand-green),#1e7a3f)}
     .cta.red{background:linear-gradient(135deg,var(--brand-red),#b91c1c)}
     .ghost{border:1px solid #e2e8f0;padding:.5rem 1rem;border-radius:.8rem;font-weight:700;text-decoration:none}
-    .hamb{display:inline-flex;border:1px solid #e2e8f0;border-radius:.8rem;padding:.4rem .6rem}@media(min-width:768px){.hamb{display:none}}.mob{border-top:1px solid #e2e8f0;background:#fff}.mlink{display:block;padding:.7rem 1rem;text-decoration:none;font-weight:600}.mlink:hover{background:#e2e8f0}.mlink.special{background:var(--brand-red);color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
+    .hamb{display:inline-flex;border:1px solid #e2e8f0;border-radius:.8rem;padding:.4rem .6rem}@media(min-width:768px){.hamb{display:none}}.mob{border-top:1px solid #e2e8f0;background:#fff}.mlink{display:block;padding:.7rem 1rem;text-decoration:none;font-weight:500;font-size:.95rem}.mlink:hover{background:#e2e8f0}.mlink.special{background:var(--brand-red);color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
     .mob .mitem{border-top:1px solid #e2e8f0}
-    .mob .mhead{display:block;width:100%;padding:.7rem 1rem;font-weight:600;text-align:left;background:transparent;border:0}
+    .mob .mhead{display:block;width:100%;padding:.7rem 1rem;font-weight:500;font-size:.95rem;text-align:left;background:transparent;border:0}
     .mob .mhead::after{content:"\25BE";float:right;transition:transform .2s}
     .mob .mhead.open{background:#e2e8f0}
     .mob .mhead.open::after{transform:rotate(180deg)}
     .mob .msub{display:none;flex-direction:column}
     .mob .msub.open{display:flex}
-    .mob .msub .mlink{padding:.5rem 1.5rem;border-top:1px solid #e2e8f0;font-weight:500}
+    .mob .msub .mlink{padding:.5rem 1.5rem;border-top:1px solid #e2e8f0;font-weight:400;font-size:.9rem}
     .mega{position:relative}
     .mega .panel{position:absolute;left:50%;top:100%;transform:translateX(-50%);width:min(320px,92vw);background:#fff;backdrop-filter:none;opacity:1;border:1px solid #e2e8f0;border-radius:1rem;box-shadow:0 24px 60px rgba(2,6,23,.15);padding:1rem;display:none;grid-template-columns:1fr;gap:.5rem;z-index:50}
     .mega .panel .col{display:flex;flex-direction:column}
@@ -93,6 +93,13 @@
     .club-card img{width:100%;max-height:320px;object-fit:cover;border-radius:1rem}
     .club-info .btns{justify-content:flex-start;margin-top:1rem}
 
-    .nav-btn.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;font-weight:700}
+    .nav-btn.login{background:linear-gradient(135deg,#4ade80,#f87171);color:#fff;font-weight:700}
     .nav-btn.login:hover,.nav-btn.login:focus{opacity:.9}
-    .mlink.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
+    .mlink.login{background:linear-gradient(135deg,#4ade80,#f87171);color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
+
+    #decor .balloon,#decor .kite{pointer-events:auto;cursor:pointer}
+    #decor .balloon{position:absolute;background:radial-gradient(circle at 30% 30%,#ffe4e6,#fb7185);border-radius:50%}
+    #decor .balloon::after{content:"";position:absolute;left:50%;top:100%;width:2px;height:60px;background:#94a3b8;transform-origin:top;animation:sway 3s ease-in-out infinite}
+    #decor .kite{position:absolute;background:linear-gradient(135deg,#bbf7d0,#fecaca);clip-path:polygon(50% 0,100% 50%,50% 100%,0 50%)}
+    #decor .kite::after{content:"";position:absolute;left:50%;top:100%;width:2px;height:80px;background:#94a3b8;transform-origin:top;animation:sway 4s ease-in-out infinite}
+    @keyframes sway{0%,100%{transform:rotate(4deg)}50%{transform:rotate(-4deg)}}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -280,4 +280,76 @@ function initCommon(){
   gsap.from('#masthead',{y:-60,opacity:0,duration:.6});
   const revealItems=document.querySelectorAll('.section,.card');
   const io2=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){gsap.to(e.target,{opacity:1,y:0,duration:.6});io2.unobserve(e.target);}})},{threshold:.2});
-  revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});}
+  revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});
+
+  let decor=document.getElementById('decor');
+  if(!decor){
+    decor=document.createElement('div');
+    decor.id='decor';
+    document.body.prepend(decor);
+  }
+  const nav=document.querySelector('.nav');
+  let animToggle,animToggleM;
+  if(nav){
+    animToggle=document.createElement('button');
+    animToggle.id='animToggle';
+    animToggle.className='nav-btn';
+    animToggle.type='button';
+    nav.appendChild(animToggle);
+  }
+  if(mobileNav){
+    animToggleM=document.createElement('button');
+    animToggleM.id='animToggleM';
+    animToggleM.className='mlink';
+    mobileNav.appendChild(animToggleM);
+  }
+  let animOn=localStorage.getItem('anim')!=='off';
+  const updateToggle=()=>{
+    if(animToggle) animToggle.innerHTML='<i class="fa-solid fa-wind mr-1"></i>Animations: '+(animOn?'On':'Off');
+    if(animToggleM) animToggleM.innerHTML='<i class="fa-solid fa-wind mr-2"></i>Animations: '+(animOn?'On':'Off');
+  };
+  const random=(min,max)=>Math.random()*(max-min)+min;
+  const popBalloon=b=>{gsap.killTweensOf(b);gsap.to(b,{scale:1.2,opacity:0,duration:.3,onComplete:()=>b.remove()});};
+  const popKite=k=>{gsap.killTweensOf(k);gsap.to(k,{rotation:180,scale:.8,duration:.3});gsap.to(k,{y:window.innerHeight+200,duration:1.5,ease:'power1.in',onComplete:()=>{k.remove();if(animOn) createKite();}});};
+  const createBalloon=()=>{
+    if(!animOn) return;
+    const b=document.createElement('div');
+    b.className='balloon';
+    const size=random(40,80);
+    b.style.width=size+'px';
+    b.style.height=size+'px';
+    b.style.left=random(0,window.innerWidth-size)+'px';
+    b.style.bottom='-120px';
+    decor.appendChild(b);
+    gsap.to(b,{y:-window.innerHeight-200,duration:random(20,40),ease:'none',onComplete:()=>{b.remove();if(animOn) createBalloon();}});
+    gsap.to(b,{x:'+=40',repeat:-1,yoyo:true,duration:random(3,6),ease:'sine.inOut'});
+    b.addEventListener('click',()=>popBalloon(b));
+  };
+  const createKite=()=>{
+    if(!animOn) return;
+    const k=document.createElement('div');
+    k.className='kite';
+    const size=random(50,80);
+    k.style.width=size+'px';
+    k.style.height=size+'px';
+    k.style.left=random(0,window.innerWidth-size)+'px';
+    k.style.top=random(0,window.innerHeight/2)+'px';
+    decor.appendChild(k);
+    gsap.to(k,{x:'+=100',repeat:-1,yoyo:true,duration:random(5,9),ease:'sine.inOut'});
+    gsap.to(k,{y:'+=60',repeat:-1,yoyo:true,duration:random(4,6),ease:'sine.inOut'});
+    k.addEventListener('click',()=>popKite(k));
+  };
+  const spawn=()=>{
+    for(let i=0;i<5;i++) setTimeout(createBalloon,i*3000);
+    for(let i=0;i<3;i++) setTimeout(createKite,i*5000);
+  };
+  const toggleAnim=()=>{
+    animOn=!animOn;
+    localStorage.setItem('anim',animOn?'on':'off');
+    if(!animOn){decor.innerHTML='';} else {spawn();}
+    updateToggle();
+  };
+  [animToggle,animToggleM].forEach(btn=>{if(btn) btn.addEventListener('click',()=>{toggleAnim();if(btn===animToggleM){mobileNav.classList.add('hidden');updateMast();}});});
+  updateToggle();
+  if(animOn) spawn();
+}


### PR DESCRIPTION
## Summary
- animate balloons and kites in the background with realistic movement and pop/fall interactions
- provide animation toggle in the menu and soften menu typography and login colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c05555bfbc832bb64f8fd1e500eaee