### PR TITLE
feat: add staff preview and fade overlay

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -97,3 +97,4 @@
     .nav-btn.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;font-weight:600}
     .nav-btn.login:hover,.nav-btn.login:focus{opacity:.9}
     .mlink.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
+    .fade-bottom{position:absolute;bottom:0;left:0;width:100%;height:50%;pointer-events:none;background:linear-gradient(to bottom,rgba(248,250,252,0),#f8fafc)}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -77,6 +77,20 @@ function initCommon(){
     }).catch(()=>{});
   });
   (function(){const track=document.getElementById('tickerTrack');if(!track)return;track.innerHTML=track.innerHTML+track.innerHTML;})();
+  const applyFade=(wrap,rows)=>{
+    if(!wrap) return;
+    const calc=()=>{
+      const card=wrap.querySelector(':scope > *');
+      if(!card) return;
+      const gap=parseFloat(getComputedStyle(wrap).gap)||0;
+      const ch=card.getBoundingClientRect().height;
+      wrap.style.maxHeight=(ch*rows+gap*(rows-1)+ch*0.2)+'px';
+    };
+    calc();
+    window.addEventListener('resize',calc);
+    window.addEventListener('load',calc);
+  };
+
   const staffHome=document.getElementById('staffsHome');
   const staffWrap=document.getElementById('staffsAll');
   if(staffHome||staffWrap){
@@ -150,8 +164,11 @@ function initCommon(){
       };
       if(staffHome){
         staffHome.innerHTML='';
-        const max=window.matchMedia('(min-width:1024px)').matches?4:(window.matchMedia('(min-width:640px)').matches?3:2);
-        staffs.slice(0,max).forEach(s=>staffHome.appendChild(createCard(s,false)));
+        const cols=window.matchMedia('(min-width:1024px)').matches?4:(window.matchMedia('(min-width:640px)').matches?3:2);
+        const visibleRows=window.matchMedia('(min-width:640px)').matches?1:2;
+        const total=cols*(visibleRows+1);
+        staffs.slice(0,total).forEach(s=>staffHome.appendChild(createCard(s,false)));
+        applyFade(staffHome,visibleRows);
       }
       if(staffWrap){
         staffWrap.innerHTML='';

--- a/frontend/components/teachers.js
+++ b/frontend/components/teachers.js
@@ -98,11 +98,28 @@ function createCard(t,root,full){
   return card;
 }
 
+function applyFade(wrap,rows){
+  if(!wrap) return;
+  const calc=()=>{
+    const card=wrap.querySelector(':scope > *');
+    if(!card) return;
+    const gap=parseFloat(getComputedStyle(wrap).gap)||0;
+    const ch=card.getBoundingClientRect().height;
+    wrap.style.maxHeight=(ch*rows+gap*(rows-1)+ch*0.2)+'px';
+  };
+  calc();
+  window.addEventListener('resize',calc);
+  window.addEventListener('load',calc);
+}
+
 function renderHome(teachers,root){
   const wrap=document.getElementById('teachersHome');
   if(!wrap) return;
-  const max=window.matchMedia('(min-width:1024px)').matches?8:6;
-  teachers.slice(0,max).forEach(t=>wrap.appendChild(createCard(t,root,false)));
+  const cols=window.matchMedia('(min-width:1024px)').matches?4:(window.matchMedia('(min-width:640px)').matches?3:2);
+  const visibleRows=2;
+  const total=cols*(visibleRows+1);
+  teachers.slice(0,total).forEach(t=>wrap.appendChild(createCard(t,root,false)));
+  applyFade(wrap,visibleRows);
 }
 
 function renderTeachersPage(teachers,root){

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -114,8 +114,26 @@
 
   <section id="achievements" class="section"><div class="wrap"><div class="head"><h2>Achievements</h2><span class="muted">Be a Champion</span></div><div class="counters"><div class="counter"><span data-count="38">0</span><label>Competition Trophies</label></div><div class="counter"><span data-count="12">0</span><label>Active Clubs</label></div><div class="counter"><span data-count="120">0</span><label>Total Teachers</label></div></div><div class="mt-6 flex flex-col md:flex-row items-center gap-6"><img loading="lazy" decoding="async" class="rounded-xl shadow" src="assets/achievement-placeholder.png" alt="Champion team"></div></div></section>
   <div class="divider wave flip" aria-hidden="true"></div>
-  <section id="teachers" class="section"><div class="wrap"><div class="head"><h2>Our Respected Teachers</h2></div><div id="teachersHome" class="grid gap-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4"></div><div class="mt-6 text-center"><a class="cta green" href="pages/teachers.html">See More</a></div></div></section>
-  <section id="staffs" class="section"><div class="wrap"><div class="head"><h2>Our Dedicated Staff</h2><span class="muted">সাফল্যের নেপথ্যের নিঃশব্দ সহযোদ্ধা</span></div><div id="staffsHome" class="grid gap-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4"></div><div class="mt-6 text-center"><a class="cta red" href="pages/staffs.html">See More</a></div></div></section>
+  <section id="teachers" class="section">
+    <div class="wrap">
+      <div class="head"><h2>Our Respected Teachers</h2></div>
+      <div class="relative">
+        <div id="teachersHome" class="grid gap-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 overflow-hidden"></div>
+        <div class="fade-bottom"></div>
+      </div>
+      <div class="mt-6 text-center"><a class="cta green" href="pages/teachers.html">See More</a></div>
+    </div>
+  </section>
+  <section id="staffs" class="section">
+    <div class="wrap">
+      <div class="head"><h2>Our Dedicated Staff</h2><span class="muted">সাফল্যের নেপথ্যের নিঃশব্দ সহযোদ্ধা</span></div>
+      <div class="relative">
+        <div id="staffsHome" class="grid gap-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 overflow-hidden"></div>
+        <div class="fade-bottom"></div>
+      </div>
+      <div class="mt-6 text-center"><a class="cta red" href="pages/staffs.html">See More</a></div>
+    </div>
+  </section>
   <div class="divider wave" aria-hidden="true"></div>
 
   <section id="academics" class="section"><div class="wrap"><div class="head"><h2>Academics</h2><span class="muted">Curriculum • HSC • ICT</span></div><div class="grid cards"><article class="card pop"><h3>Curriculum</h3><p>Grade 6–10 • HSC Science, Commerce, Arts.</p></article><article id="resources" class="card pop"><h3>Resources</h3><p>Syllabus & Notes (PDF), Question Bank, e-Library.</p></article><article class="card pop"><h3>Exams</h3><p>Term Exams, Model Tests, Practicals, Results.</p></article></div></div></section>


### PR DESCRIPTION
## Summary
- show extra staff cards on mobile and add fade hint for more
- apply gradient overlay to teacher and staff sections
- add helper for calculating partial row height

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c13f6a11f8832b8cd68b1168f959aa