### PR TITLE
Remove icons from navigation menus

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -17,7 +17,6 @@
     .controls{display:flex;align-items:center;gap:.5rem;flex-shrink:0}
     .nav{display:none;gap:.25rem;align-items:center;flex:1;justify-content:flex-end}@media(min-width:768px){.nav{display:flex}}.nav-btn{padding:.4rem .6rem;border-radius:.75rem;font-weight:500;font-size:.95rem}
     .nav-btn.icon{padding:.5rem;font-size:1.25rem;line-height:1}
-    .nav-btn i,.mlink i,.mhead i{font-weight:400;font-size:.9em}
     .mega>.nav-btn::after{content:"\25BE";margin-left:.25rem;font-size:.65em;display:inline-block;transition:transform .2s}
     .mega.open>.nav-btn::after{transform:rotate(180deg)}
     .cta{padding:.55rem 1rem;border-radius:.8rem;font-weight:800;text-decoration:none;box-shadow:0 4px 8px rgba(2,6,23,.08);color:#fff}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="pages/clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="pages/facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="pages/transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="pages/staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="pages/governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="pages/teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="pages/staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="#houses">Houses</a><a href="#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="#resources">Syllabus (PDF)</a><a href="#resources">Question Bank</a><a href="#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="#facilities">Labs & Library</a><a href="#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="pages/clubs.html">Clubs & Societies</a><a href="#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="pages/facilities.html">Overview</a><a href="pages/transport.html">Transport</a><a href="pages/staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="pages/governing.html">Governing Body</a><a href="pages/teachers.html">Teachers</a><a href="pages/staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="#houses">Houses</a>
+        <a class="mlink" href="#classes">Classes</a>
+        <a class="mlink" href="#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="#resources">Question Bank</a>
+        <a class="mlink" href="#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="pages/clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="#facilities">Playgrounds</a>
+        <a class="mlink" href="pages/clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="#gallery">Gallery</a>
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+        <button class="mhead">Facilities</button>
         <div class="msub">
-          <a class="mlink" href="pages/facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-          <a class="mlink" href="pages/transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-          <a class="mlink" href="pages/staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+          <a class="mlink" href="pages/facilities.html">Overview</a>
+          <a class="mlink" href="pages/transport.html">Transport</a>
+          <a class="mlink" href="pages/staff-quarter.html">Staff Quarter</a>
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+        <button class="mhead">Administration</button>
         <div class="msub">
-          <a class="mlink" href="pages/governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-          <a class="mlink" href="pages/teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-          <a class="mlink" href="pages/staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+          <a class="mlink" href="pages/governing.html">Governing Body</a>
+          <a class="mlink" href="pages/teachers.html">Teachers</a>
+          <a class="mlink" href="pages/staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/clubs.html
+++ b/frontend/pages/clubs.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="../index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+        <button class="mhead">Facilities</button>
         <div class="msub">
-          <a class="mlink" href="facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-          <a class="mlink" href="transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-          <a class="mlink" href="staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+          <a class="mlink" href="facilities.html">Overview</a>
+          <a class="mlink" href="transport.html">Transport</a>
+          <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+        <button class="mhead">Administration</button>
         <div class="msub">
-          <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-          <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-          <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+          <a class="mlink" href="governing.html">Governing Body</a>
+          <a class="mlink" href="teachers.html">Teachers</a>
+          <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/facilities.html
+++ b/frontend/pages/facilities.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="../index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+      <button class="mhead">Facilities</button>
       <div class="msub">
-        <a class="mlink" href="facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-        <a class="mlink" href="transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-        <a class="mlink" href="staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+        <a class="mlink" href="facilities.html">Overview</a>
+        <a class="mlink" href="transport.html">Transport</a>
+        <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+      <button class="mhead">Administration</button>
       <div class="msub">
-        <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-        <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-        <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html">Teachers</a>
+        <a class="mlink" href="staffs.html">Staffs</a>
       </div>
     </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="../index.html#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="../index.html#" class="tick">HSC Model Test Routine — Download PDF</a><a href="../index.html#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="../index.html#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/governing.html
+++ b/frontend/pages/governing.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="../index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+        <button class="mhead">Facilities</button>
         <div class="msub">
-          <a class="mlink" href="facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-          <a class="mlink" href="transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-          <a class="mlink" href="staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+          <a class="mlink" href="facilities.html">Overview</a>
+          <a class="mlink" href="transport.html">Transport</a>
+          <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+        <button class="mhead">Administration</button>
         <div class="msub">
-          <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-          <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-          <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+          <a class="mlink" href="governing.html">Governing Body</a>
+          <a class="mlink" href="teachers.html">Teachers</a>
+          <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/notice.html
+++ b/frontend/pages/notice.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="../index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+        <button class="mhead">Facilities</button>
         <div class="msub">
-          <a class="mlink" href="facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-          <a class="mlink" href="transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-          <a class="mlink" href="staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+          <a class="mlink" href="facilities.html">Overview</a>
+          <a class="mlink" href="transport.html">Transport</a>
+          <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+        <button class="mhead">Administration</button>
         <div class="msub">
-          <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-          <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-          <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+          <a class="mlink" href="governing.html">Governing Body</a>
+          <a class="mlink" href="teachers.html">Teachers</a>
+          <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/staff-quarter.html
+++ b/frontend/pages/staff-quarter.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="../index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+      <button class="mhead">Facilities</button>
       <div class="msub">
-        <a class="mlink" href="facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-        <a class="mlink" href="transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-        <a class="mlink" href="staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+        <a class="mlink" href="facilities.html">Overview</a>
+        <a class="mlink" href="transport.html">Transport</a>
+        <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+      <button class="mhead">Administration</button>
       <div class="msub">
-        <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-        <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-        <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html">Teachers</a>
+        <a class="mlink" href="staffs.html">Staffs</a>
       </div>
     </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="../index.html#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="../index.html#" class="tick">HSC Model Test Routine — Download PDF</a><a href="../index.html#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="../index.html#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/staffs.html
+++ b/frontend/pages/staffs.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="../index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+        <button class="mhead">Facilities</button>
         <div class="msub">
-          <a class="mlink" href="facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-          <a class="mlink" href="transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-          <a class="mlink" href="staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+          <a class="mlink" href="facilities.html">Overview</a>
+          <a class="mlink" href="transport.html">Transport</a>
+          <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+        <button class="mhead">Administration</button>
         <div class="msub">
-          <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-          <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-          <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+          <a class="mlink" href="governing.html">Governing Body</a>
+          <a class="mlink" href="teachers.html">Teachers</a>
+          <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/student-galleries.html
+++ b/frontend/pages/student-galleries.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="../index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+        <button class="mhead">Facilities</button>
         <div class="msub">
-          <a class="mlink" href="facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-          <a class="mlink" href="transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-          <a class="mlink" href="staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+          <a class="mlink" href="facilities.html">Overview</a>
+          <a class="mlink" href="transport.html">Transport</a>
+          <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+        <button class="mhead">Administration</button>
         <div class="msub">
-          <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-          <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-          <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+          <a class="mlink" href="governing.html">Governing Body</a>
+          <a class="mlink" href="teachers.html">Teachers</a>
+          <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/teachers.html
+++ b/frontend/pages/teachers.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="../index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+        <button class="mhead">Facilities</button>
         <div class="msub">
-          <a class="mlink" href="facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-          <a class="mlink" href="transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-          <a class="mlink" href="staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+          <a class="mlink" href="facilities.html">Overview</a>
+          <a class="mlink" href="transport.html">Transport</a>
+          <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+        <button class="mhead">Administration</button>
         <div class="msub">
-          <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-          <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-          <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+          <a class="mlink" href="governing.html">Governing Body</a>
+          <a class="mlink" href="teachers.html">Teachers</a>
+          <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/transport.html
+++ b/frontend/pages/transport.html
@@ -22,56 +22,56 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house mr-1"></i>Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap mr-1"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-1"></i>Houses</a><a href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-1"></i>Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources"><i class="fa-solid fa-file-lines mr-1"></i>Syllabus (PDF)</a><a href="../index.html#resources"><i class="fa-solid fa-circle-question mr-1"></i>Question Bank</a><a href="../index.html#resources"><i class="fa-solid fa-book mr-1"></i>e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school mr-1"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities"><i class="fa-solid fa-flask mr-1"></i>Labs & Library</a><a href="../index.html#facilities"><i class="fa-solid fa-futbol mr-1"></i>Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html"><i class="fa-solid fa-people-group mr-1"></i>Clubs & Societies</a><a href="../index.html#gallery"><i class="fa-solid fa-images mr-1"></i>Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-building mr-1"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html"><i class="fa-solid fa-building mr-1"></i>Overview</a><a href="transport.html"><i class="fa-solid fa-bus mr-1"></i>Transport</a><a href="staff-quarter.html"><i class="fa-solid fa-house-user mr-1"></i>Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear mr-1"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html"><i class="fa-solid fa-landmark mr-1"></i>Governing Body</a><a href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-1"></i>Teachers</a><a href="staffs.html"><i class="fa-solid fa-users mr-1"></i>Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-1"></i>Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-1"></i>Login</a>
+        <a class="nav-btn" href="../index.html">Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
       </nav>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html"><i class="fa-solid fa-house mr-2"></i>Home</a>
+    <a class="mlink" href="../index.html">Home</a>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-graduation-cap mr-2"></i>Academics</button>
+      <button class="mhead">Academics</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#houses"><i class="fa-solid fa-house-chimney mr-2"></i>Houses</a>
-        <a class="mlink" href="../index.html#classes"><i class="fa-solid fa-chalkboard mr-2"></i>Classes</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-file-lines mr-2"></i>Syllabus (PDF)</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-circle-question mr-2"></i>Question Bank</a>
-        <a class="mlink" href="../index.html#resources"><i class="fa-solid fa-book mr-2"></i>e-Library</a>
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-school mr-2"></i>Campus</button>
+      <button class="mhead">Campus</button>
       <div class="msub">
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-flask mr-2"></i>Labs &amp; Library</a>
-        <a class="mlink" href="../index.html#facilities"><i class="fa-solid fa-futbol mr-2"></i>Playgrounds</a>
-        <a class="mlink" href="clubs.html"><i class="fa-solid fa-people-group mr-2"></i>Clubs &amp; Societies</a>
-        <a class="mlink" href="../index.html#gallery"><i class="fa-solid fa-images mr-2"></i>Gallery</a>
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-building mr-2"></i>Facilities</button>
+      <button class="mhead">Facilities</button>
       <div class="msub">
-        <a class="mlink" href="facilities.html"><i class="fa-solid fa-building mr-2"></i>Overview</a>
-        <a class="mlink" href="transport.html"><i class="fa-solid fa-bus mr-2"></i>Transport</a>
-        <a class="mlink" href="staff-quarter.html"><i class="fa-solid fa-house-user mr-2"></i>Staff Quarter</a>
+        <a class="mlink" href="facilities.html">Overview</a>
+        <a class="mlink" href="transport.html">Transport</a>
+        <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead"><i class="fa-solid fa-users-gear mr-2"></i>Administration</button>
+      <button class="mhead">Administration</button>
       <div class="msub">
-        <a class="mlink" href="governing.html"><i class="fa-solid fa-landmark mr-2"></i>Governing Body</a>
-        <a class="mlink" href="teachers.html"><i class="fa-solid fa-chalkboard-user mr-2"></i>Teachers</a>
-        <a class="mlink" href="staffs.html"><i class="fa-solid fa-users mr-2"></i>Staffs</a>
+        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html">Teachers</a>
+        <a class="mlink" href="staffs.html">Staffs</a>
       </div>
     </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen mr-2"></i>Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket mr-2"></i>Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="../index.html#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="../index.html#" class="tick">HSC Model Test Routine — Download PDF</a><a href="../index.html#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="../index.html#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>


### PR DESCRIPTION
## Summary
- Remove Font Awesome icons from desktop and mobile navigation menus across the site.
- Drop now-unused icon CSS selector from common styles.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c39b3a6ec8832b9f383a19f60f5cd4