### PR TITLE
Add icons to navigation and mobile home shortcut

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -15,18 +15,23 @@
     .btext strong{display:block;font-weight:900}
     .btext span{display:block;font-size:.78rem;color:#64748b}
     .controls{display:flex;align-items:center;gap:.5rem;flex-shrink:0}
-    .nav{display:none;gap:.25rem;align-items:center;flex:1;justify-content:flex-end}@media(min-width:768px){.nav{display:flex}}.nav-btn{padding:.4rem .6rem;border-radius:.75rem;font-weight:500;font-size:.95rem}
-    .nav-btn.icon{padding:.5rem;font-size:1.25rem;line-height:1}
+    .nav{display:none;gap:.25rem;align-items:center;flex:1;justify-content:flex-end}@media(min-width:768px){.nav{display:flex}}.nav-btn{display:inline-flex;align-items:center;gap:.35rem;padding:.4rem .6rem;border-radius:.75rem;font-weight:500;font-size:.95rem}
+    .nav-btn.icon{padding:.5rem;font-size:1.25rem;line-height:1;gap:0}
+    .nav-btn i{color:#64748b}
+    .nav-btn.login i{color:inherit}
+    .mlink i,.mob .mhead i{color:#64748b}
+    .mlink.login i{color:inherit}
+    .mobile-home{display:inline-flex}@media(min-width:768px){.mobile-home{display:none}}
     .mega>.nav-btn::after{content:"\25BE";margin-left:.25rem;font-size:.65em;display:inline-block;transition:transform .2s}
     .mega.open>.nav-btn::after{transform:rotate(180deg)}
     .cta{padding:.55rem 1rem;border-radius:.8rem;font-weight:800;text-decoration:none;box-shadow:0 4px 8px rgba(2,6,23,.08);color:#fff}
     .cta.green{background:linear-gradient(135deg,var(--brand-green),#1e7a3f)}
     .cta.red{background:linear-gradient(135deg,var(--brand-red),#b91c1c)}
     .ghost{border:1px solid #e2e8f0;padding:.5rem 1rem;border-radius:.8rem;font-weight:700;text-decoration:none}
-    .hamb{display:inline-flex;border:1px solid #e2e8f0;border-radius:.8rem;padding:.4rem .6rem}@media(min-width:768px){.hamb{display:none}}.mob{border-top:1px solid #e2e8f0;background:#fff}.mlink{display:block;padding:.7rem 1rem;text-decoration:none;font-weight:500;font-size:.95rem}.mlink:hover{background:#e2e8f0}.mlink.special{background:var(--brand-red);color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
+    .hamb{display:inline-flex;border:1px solid #e2e8f0;border-radius:.8rem;padding:.4rem .6rem}@media(min-width:768px){.hamb{display:none}}.mob{border-top:1px solid #e2e8f0;background:#fff}.mlink{display:flex;align-items:center;gap:.5rem;padding:.7rem 1rem;text-decoration:none;font-weight:500;font-size:.95rem;width:100%}.mlink:hover{background:#e2e8f0}.mlink.special{background:var(--brand-red);color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
     .mob .mitem{border-top:1px solid #e2e8f0}
-    .mob .mhead{display:block;width:100%;padding:.7rem 1rem;font-weight:500;font-size:.95rem;text-align:left;background:transparent;border:0}
-    .mob .mhead::after{content:"\25BE";float:right;transition:transform .2s}
+    .mob .mhead{display:flex;align-items:center;gap:.5rem;width:100%;padding:.7rem 1rem;font-weight:500;font-size:.95rem;text-align:left;background:transparent;border:0}
+    .mob .mhead::after{content:"\25BE";margin-left:auto;transition:transform .2s}
     .mob .mhead.open{background:#e2e8f0}
     .mob .mhead.open::after{transform:rotate(180deg)}
     .mob .msub{display:none;flex-direction:column}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="#houses">Houses</a><a href="#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="#resources">Syllabus (PDF)</a><a href="#resources">Question Bank</a><a href="#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="#facilities">Labs & Library</a><a href="#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="pages/clubs.html">Clubs & Societies</a><a href="#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="pages/facilities.html">Overview</a><a href="pages/transport.html">Transport</a><a href="pages/staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="pages/governing.html">Governing Body</a><a href="pages/teachers.html">Teachers</a><a href="pages/staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="#houses">Houses</a><a href="#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="#resources">Syllabus (PDF)</a><a href="#resources">Question Bank</a><a href="#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="#facilities">Labs & Library</a><a href="#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="pages/clubs.html">Clubs & Societies</a><a href="#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="pages/facilities.html">Overview</a><a href="pages/transport.html">Transport</a><a href="pages/staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="pages/governing.html">Governing Body</a><a href="pages/teachers.html">Teachers</a><a href="pages/staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="index.html">Home</a>
+    <a class="mlink" href="index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="#houses">Houses</a>
         <a class="mlink" href="#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="#facilities">Labs &amp; Library</a>
         <a class="mlink" href="#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead">Facilities</button>
+        <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
         <div class="msub">
           <a class="mlink" href="pages/facilities.html">Overview</a>
           <a class="mlink" href="pages/transport.html">Transport</a>
@@ -63,15 +64,15 @@
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead">Administration</button>
+        <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
         <div class="msub">
           <a class="mlink" href="pages/governing.html">Governing Body</a>
           <a class="mlink" href="pages/teachers.html">Teachers</a>
           <a class="mlink" href="pages/staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/clubs.html
+++ b/frontend/pages/clubs.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#houses">Houses</a>
         <a class="mlink" href="../index.html#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead">Facilities</button>
+        <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
         <div class="msub">
           <a class="mlink" href="facilities.html">Overview</a>
           <a class="mlink" href="transport.html">Transport</a>
@@ -63,15 +64,15 @@
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead">Administration</button>
+        <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
         <div class="msub">
           <a class="mlink" href="governing.html">Governing Body</a>
           <a class="mlink" href="teachers.html">Teachers</a>
           <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/facilities.html
+++ b/frontend/pages/facilities.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#houses">Houses</a>
         <a class="mlink" href="../index.html#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Facilities</button>
+      <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
       <div class="msub">
         <a class="mlink" href="facilities.html">Overview</a>
         <a class="mlink" href="transport.html">Transport</a>
@@ -63,15 +64,15 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
       <div class="msub">
         <a class="mlink" href="governing.html">Governing Body</a>
         <a class="mlink" href="teachers.html">Teachers</a>
         <a class="mlink" href="staffs.html">Staffs</a>
       </div>
     </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="../index.html#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="../index.html#" class="tick">HSC Model Test Routine — Download PDF</a><a href="../index.html#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="../index.html#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/governing.html
+++ b/frontend/pages/governing.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#houses">Houses</a>
         <a class="mlink" href="../index.html#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead">Facilities</button>
+        <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
         <div class="msub">
           <a class="mlink" href="facilities.html">Overview</a>
           <a class="mlink" href="transport.html">Transport</a>
@@ -63,15 +64,15 @@
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead">Administration</button>
+        <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
         <div class="msub">
           <a class="mlink" href="governing.html">Governing Body</a>
           <a class="mlink" href="teachers.html">Teachers</a>
           <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/notice.html
+++ b/frontend/pages/notice.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#houses">Houses</a>
         <a class="mlink" href="../index.html#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead">Facilities</button>
+        <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
         <div class="msub">
           <a class="mlink" href="facilities.html">Overview</a>
           <a class="mlink" href="transport.html">Transport</a>
@@ -63,15 +64,15 @@
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead">Administration</button>
+        <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
         <div class="msub">
           <a class="mlink" href="governing.html">Governing Body</a>
           <a class="mlink" href="teachers.html">Teachers</a>
           <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/staff-quarter.html
+++ b/frontend/pages/staff-quarter.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#houses">Houses</a>
         <a class="mlink" href="../index.html#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Facilities</button>
+      <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
       <div class="msub">
         <a class="mlink" href="facilities.html">Overview</a>
         <a class="mlink" href="transport.html">Transport</a>
@@ -63,15 +64,15 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
       <div class="msub">
         <a class="mlink" href="governing.html">Governing Body</a>
         <a class="mlink" href="teachers.html">Teachers</a>
         <a class="mlink" href="staffs.html">Staffs</a>
       </div>
     </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="../index.html#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="../index.html#" class="tick">HSC Model Test Routine — Download PDF</a><a href="../index.html#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="../index.html#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/staffs.html
+++ b/frontend/pages/staffs.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#houses">Houses</a>
         <a class="mlink" href="../index.html#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead">Facilities</button>
+        <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
         <div class="msub">
           <a class="mlink" href="facilities.html">Overview</a>
           <a class="mlink" href="transport.html">Transport</a>
@@ -63,15 +64,15 @@
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead">Administration</button>
+        <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
         <div class="msub">
           <a class="mlink" href="governing.html">Governing Body</a>
           <a class="mlink" href="teachers.html">Teachers</a>
           <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/student-galleries.html
+++ b/frontend/pages/student-galleries.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#houses">Houses</a>
         <a class="mlink" href="../index.html#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead">Facilities</button>
+        <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
         <div class="msub">
           <a class="mlink" href="facilities.html">Overview</a>
           <a class="mlink" href="transport.html">Transport</a>
@@ -63,15 +64,15 @@
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead">Administration</button>
+        <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
         <div class="msub">
           <a class="mlink" href="governing.html">Governing Body</a>
           <a class="mlink" href="teachers.html">Teachers</a>
           <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/teachers.html
+++ b/frontend/pages/teachers.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#houses">Houses</a>
         <a class="mlink" href="../index.html#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
       <div class="mitem">
-        <button class="mhead">Facilities</button>
+        <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
         <div class="msub">
           <a class="mlink" href="facilities.html">Overview</a>
           <a class="mlink" href="transport.html">Transport</a>
@@ -63,15 +64,15 @@
         </div>
       </div>
       <div class="mitem">
-        <button class="mhead">Administration</button>
+        <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
         <div class="msub">
           <a class="mlink" href="governing.html">Governing Body</a>
           <a class="mlink" href="teachers.html">Teachers</a>
           <a class="mlink" href="staffs.html">Staffs</a>
         </div>
       </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>

--- a/frontend/pages/transport.html
+++ b/frontend/pages/transport.html
@@ -22,21 +22,22 @@
     </a>
     <div class="controls">
       <nav class="nav" aria-label="Primary">
-        <a class="nav-btn" href="../index.html">Home</a>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
-        <div class="mega"><button class="nav-btn" aria-haspopup="true">Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
-        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
       </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
       <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
     </div>
   </div>
   <div id="mobileNav" class="mob hidden">
-    <a class="mlink" href="../index.html">Home</a>
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
     <div class="mitem">
-      <button class="mhead">Academics</button>
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#houses">Houses</a>
         <a class="mlink" href="../index.html#classes">Classes</a>
@@ -46,7 +47,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Campus</button>
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
       <div class="msub">
         <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
         <a class="mlink" href="../index.html#facilities">Playgrounds</a>
@@ -55,7 +56,7 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Facilities</button>
+      <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
       <div class="msub">
         <a class="mlink" href="facilities.html">Overview</a>
         <a class="mlink" href="transport.html">Transport</a>
@@ -63,15 +64,15 @@
       </div>
     </div>
     <div class="mitem">
-      <button class="mhead">Administration</button>
+      <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
       <div class="msub">
         <a class="mlink" href="governing.html">Governing Body</a>
         <a class="mlink" href="teachers.html">Teachers</a>
         <a class="mlink" href="staffs.html">Staffs</a>
       </div>
     </div>
-    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply</a>
-    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">Login</a>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="../index.html#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="../index.html#" class="tick">HSC Model Test Routine — Download PDF</a><a href="../index.html#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="../index.html#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>


### PR DESCRIPTION
## Summary
- Add font-awesome icons to all primary navigation links
- Include a dedicated home icon shortcut before the mobile menu
- Style navigation elements for icon alignment and lighter appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c39ee41cb4832b9505330e8c84bae7