### PR TITLE
feat: enhance academics section with exam stats

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,7 +137,40 @@
   </section>
   <div class="divider wave" aria-hidden="true"></div>
 
-  <section id="academics" class="section"><div class="wrap"><div class="head"><h2>Academics</h2><span class="muted">Curriculum • HSC • ICT</span></div><div class="grid cards"><article class="card pop"><h3>Curriculum</h3><p>Grade 6–10 • HSC Science, Commerce, Arts.</p></article><article id="resources" class="card pop"><h3>Resources</h3><p>Syllabus & Notes (PDF), Question Bank, e-Library.</p></article><article class="card pop"><h3>Exams</h3><p>Term Exams, Model Tests, Practicals, Results.</p></article></div></div></section>
+  <section id="academics" class="section">
+    <div class="wrap">
+      <div class="head">
+        <h2>Academics</h2>
+        <span class="muted">From Primary to College &mdash; Board Exam Excellence</span>
+      </div>
+      <div class="grid cards">
+        <article class="card pop">
+          <h3>Primary (Class 3&ndash;5)</h3>
+          <p>Creative foundation with caring mentors and digital classrooms.</p>
+        </article>
+        <article class="card pop">
+          <h3>Secondary (Class 6&ndash;10)</h3>
+          <p>Rigorous preparation for SSC; students in classes 3&ndash;8 consistently secure top marks.</p>
+        </article>
+        <article class="card pop">
+          <h3>College (Class 11&ndash;12)</h3>
+          <p>Science, Commerce &amp; Arts streams leading to HSC excellence.</p>
+        </article>
+      </div>
+      <div class="grid gap-4 md:grid-cols-2 mt-8">
+        <article class="card">
+          <h3 class="text-xl font-bold mb-2">SSC Results</h3>
+          <p class="text-4xl font-extrabold text-green-700">100% Pass</p>
+          <p class="mt-1"><span class="font-semibold">80%</span> GPA&nbsp;5 in recent years</p>
+        </article>
+        <article class="card">
+          <h3 class="text-xl font-bold mb-2">HSC Results</h3>
+          <p class="text-4xl font-extrabold text-green-700">100% Pass</p>
+          <p class="mt-1"><span class="font-semibold">70%</span> GPA&nbsp;5 in recent years</p>
+        </article>
+      </div>
+    </div>
+  </section>
 
   <section id="houses" class="section">
     <div class="wrap">


### PR DESCRIPTION
## Summary
- restructure homepage academics section for primary, secondary and college programs
- highlight 100% pass rate with GPA 5 stats for SSC and HSC

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a4d64570832bb655b12737e3be4a