### PR TITLE
feat: add animated exam result cards

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -102,3 +102,9 @@
     .nav-btn.login:hover,.nav-btn.login:focus{opacity:.9}
     .mlink.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
     .fade-bottom{position:absolute;bottom:0;left:0;width:100%;height:50%;pointer-events:none;background:linear-gradient(to bottom,rgba(248,250,252,0),#f8fafc)}
+    .result-card{position:relative;overflow:hidden}
+    .rate{transition:color .2s}
+    .rate.celebrate{animation:yay .8s ease}
+    @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
+    .confetti{position:absolute;top:0;font-size:1.25rem;animation:confetti 1.5s linear forwards;pointer-events:none}
+    @keyframes confetti{to{transform:translateY(150%) rotate(720deg);opacity:0}}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -276,6 +276,56 @@ function initCommon(){
     });
   },{threshold:.4});
   counters.forEach(c=>io.observe(c));
+
+  const rates=document.querySelectorAll('#academics .rate[data-count]');
+  const rateIO=new IntersectionObserver(entries=>{
+    entries.forEach(e=>{
+      if(e.isIntersecting){
+        const el=e.target,end=parseInt(el.dataset.count,10);
+        let start=null;
+        const duration=2500;
+        const step=t=>{
+          if(start===null) start=t;
+          const progress=Math.min((t-start)/duration,1);
+          const val=Math.floor(progress*end);
+          el.textContent=val;
+          if(progress<0.33){
+            el.classList.add('text-yellow-500');
+            el.classList.remove('text-green-600','text-red-600');
+          }else if(progress<0.66){
+            el.classList.add('text-green-600');
+            el.classList.remove('text-yellow-500','text-red-600');
+          }else{
+            el.classList.add('text-red-600');
+            el.classList.remove('text-yellow-500','text-green-600');
+          }
+          if(progress<1){
+            requestAnimationFrame(step);
+          }else{
+            el.classList.add('celebrate');
+            gsap.fromTo(el,{scale:1.4},{scale:1,duration:.6,ease:'bounce.out'});
+            launchConfetti(el);
+          }
+        };
+        requestAnimationFrame(step);
+        rateIO.unobserve(el);
+      }
+    });
+  },{threshold:.6});
+  rates.forEach(r=>rateIO.observe(r));
+
+  function launchConfetti(el){
+    const card=el.closest('.result-card');
+    if(!card) return;
+    for(let i=0;i<12;i++){
+      const s=document.createElement('span');
+      s.className='confetti';
+      s.textContent='🎉';
+      s.style.left=Math.random()*100+'%';
+      card.appendChild(s);
+      setTimeout(()=>s.remove(),1500);
+    }
+  }
   document.querySelectorAll('.strip.loop').forEach(strip=>{
     const kids=[...strip.children];
     kids.forEach(el=>strip.appendChild(el.cloneNode(true)));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -141,32 +141,34 @@
     <div class="wrap">
       <div class="head">
         <h2>Academics</h2>
-        <span class="muted">From Primary to College &mdash; Board Exam Excellence</span>
+        <span class="muted">Board Exam Excellence</span>
       </div>
-      <div class="grid cards">
-        <article class="card pop">
-          <h3>Primary (Class 3&ndash;5)</h3>
-          <p>Creative foundation with caring mentors and digital classrooms.</p>
+      <div class="grid gap-4 md:grid-cols-2">
+        <article class="card result-card p-8">
+          <h3 class="text-5xl font-extrabold text-center mb-6">SSC</h3>
+          <div class="flex justify-between text-3xl font-extrabold">
+            <div class="flex flex-col items-center flex-1">
+              <div class="flex items-baseline"><span class="rate text-yellow-500" data-count="100">0</span><span>%</span></div>
+              <span class="mt-2 text-base font-semibold">Pass</span>
+            </div>
+            <div class="flex flex-col items-center flex-1">
+              <div class="flex items-baseline"><span class="rate text-yellow-500" data-count="80">0</span><span>%</span></div>
+              <span class="mt-2 text-base font-semibold">GPA 5</span>
+            </div>
+          </div>
         </article>
-        <article class="card pop">
-          <h3>Secondary (Class 6&ndash;10)</h3>
-          <p>Rigorous preparation for SSC; students in classes 3&ndash;8 consistently secure top marks.</p>
-        </article>
-        <article class="card pop">
-          <h3>College (Class 11&ndash;12)</h3>
-          <p>Science, Commerce &amp; Arts streams leading to HSC excellence.</p>
-        </article>
-      </div>
-      <div class="grid gap-4 md:grid-cols-2 mt-8">
-        <article class="card">
-          <h3 class="text-xl font-bold mb-2">SSC Results</h3>
-          <p class="text-4xl font-extrabold text-green-700">100% Pass</p>
-          <p class="mt-1"><span class="font-semibold">80%</span> GPA&nbsp;5 in recent years</p>
-        </article>
-        <article class="card">
-          <h3 class="text-xl font-bold mb-2">HSC Results</h3>
-          <p class="text-4xl font-extrabold text-green-700">100% Pass</p>
-          <p class="mt-1"><span class="font-semibold">70%</span> GPA&nbsp;5 in recent years</p>
+        <article class="card result-card p-8">
+          <h3 class="text-5xl font-extrabold text-center mb-6">HSC</h3>
+          <div class="flex justify-between text-3xl font-extrabold">
+            <div class="flex flex-col items-center flex-1">
+              <div class="flex items-baseline"><span class="rate text-yellow-500" data-count="100">0</span><span>%</span></div>
+              <span class="mt-2 text-base font-semibold">Pass</span>
+            </div>
+            <div class="flex flex-col items-center flex-1">
+              <div class="flex items-baseline"><span class="rate text-yellow-500" data-count="70">0</span><span>%</span></div>
+              <span class="mt-2 text-base font-semibold">GPA 5</span>
+            </div>
+          </div>
         </article>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace Academics cards with animated SSC/HSC result cards
- Add percentage counting with color transitions and confetti celebration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a7684bd8832ba30f4d9a86f70c7e