### PR TITLE
style academics background results

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -102,7 +102,8 @@
     .nav-btn.login:hover,.nav-btn.login:focus{opacity:.9}
     .mlink.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
     .fade-bottom{position:absolute;bottom:0;left:0;width:100%;height:50%;pointer-events:none;background:linear-gradient(to bottom,rgba(248,250,252,0),#f8fafc)}
-    .result-card{position:relative;overflow:hidden}
+    .result-card{position:relative;overflow:hidden;background:rgba(255,255,255,.7);backdrop-filter:blur(4px)}
+    .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:5rem;font-weight:900;color:rgba(15,23,42,.06);pointer-events:none;text-transform:uppercase}
     .rate{transition:color .2s}
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -311,7 +311,7 @@ function initCommon(){
         rateIO.unobserve(el);
       }
     });
-  },{threshold:.6});
+  },{threshold:.2});
   rates.forEach(r=>rateIO.observe(r));
 
   function launchConfetti(el){

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -144,31 +144,31 @@
         <span class="muted">Board Exam Excellence</span>
       </div>
       <div class="grid gap-4 md:grid-cols-2">
-        <article class="card result-card p-8">
-          <h3 class="text-5xl font-extrabold text-center mb-6">SSC</h3>
-          <div class="flex justify-between text-3xl font-extrabold">
+        <article class="card result-card p-8" data-label="SSC">
+          <div class="flex justify-between text-4xl font-extrabold">
             <div class="flex flex-col items-center flex-1">
-              <div class="flex items-baseline"><span class="rate text-yellow-500" data-count="100">0</span><span>%</span></div>
+              <div class="flex items-baseline"><span class="rate text-yellow-500 text-6xl" data-count="100">0</span><span class="text-3xl">%</span></div>
               <span class="mt-2 text-base font-semibold">Pass</span>
             </div>
             <div class="flex flex-col items-center flex-1">
-              <div class="flex items-baseline"><span class="rate text-yellow-500" data-count="80">0</span><span>%</span></div>
+              <div class="flex items-baseline"><span class="rate text-yellow-500 text-6xl" data-count="80">0</span><span class="text-3xl">%</span></div>
               <span class="mt-2 text-base font-semibold">GPA 5</span>
             </div>
           </div>
+          <p class="mt-6 text-center text-sm">in last <strong>5 years</strong></p>
         </article>
-        <article class="card result-card p-8">
-          <h3 class="text-5xl font-extrabold text-center mb-6">HSC</h3>
-          <div class="flex justify-between text-3xl font-extrabold">
+        <article class="card result-card p-8" data-label="HSC">
+          <div class="flex justify-between text-4xl font-extrabold">
             <div class="flex flex-col items-center flex-1">
-              <div class="flex items-baseline"><span class="rate text-yellow-500" data-count="100">0</span><span>%</span></div>
+              <div class="flex items-baseline"><span class="rate text-yellow-500 text-6xl" data-count="100">0</span><span class="text-3xl">%</span></div>
               <span class="mt-2 text-base font-semibold">Pass</span>
             </div>
             <div class="flex flex-col items-center flex-1">
-              <div class="flex items-baseline"><span class="rate text-yellow-500" data-count="70">0</span><span>%</span></div>
+              <div class="flex items-baseline"><span class="rate text-yellow-500 text-6xl" data-count="70">0</span><span class="text-3xl">%</span></div>
               <span class="mt-2 text-base font-semibold">GPA 5</span>
             </div>
           </div>
+          <p class="mt-6 text-center text-sm">in last <strong>5 years</strong></p>
         </article>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Style academic result cards with translucent backgrounds and large watermark labels for SSC and HSC.
- Increase percentage display size, add “in last 5 years” notes, and ensure counters animate when scrolled into view.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a991c758832b8b832dfb054a6b87