### PR TITLE
Improve result card styling for readability

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -102,8 +102,8 @@
     .nav-btn.login:hover,.nav-btn.login:focus{opacity:.9}
     .mlink.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
     .fade-bottom{position:absolute;bottom:0;left:0;width:100%;height:50%;pointer-events:none;background:linear-gradient(to bottom,rgba(248,250,252,0),#f8fafc)}
-    .result-card{position:relative;overflow:hidden;background:rgba(255,255,255,.7);backdrop-filter:blur(4px)}
-    .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:5rem;font-weight:900;color:rgba(15,23,42,.06);pointer-events:none;text-transform:uppercase}
+    .result-card{position:relative;overflow:hidden;background-color:rgba(255,255,255,.5);backdrop-filter:blur(4px);background-image:radial-gradient(circle at 20% 30%,rgba(173,216,230,.4),transparent 60%),radial-gradient(circle at 80% 70%,rgba(255,200,150,.4),transparent 60%)}
+    .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:7rem;font-weight:900;font-family:'Brush Script MT',cursive;color:rgba(15,23,42,.15);pointer-events:none;text-transform:uppercase}
     .rate{transition:color .2s}
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}


### PR DESCRIPTION
## Summary
- increase transparency and add pastel circle accents to result cards
- enlarge SSC/HSC labels with a decorative font and stronger color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3abac1970832b9fa2feeabb10315c