### PR TITLE
Enhance SSC/HSC result cards for higher contrast

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -102,8 +102,8 @@
     .nav-btn.login:hover,.nav-btn.login:focus{opacity:.9}
     .mlink.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center;justify-content:center}
     .fade-bottom{position:absolute;bottom:0;left:0;width:100%;height:50%;pointer-events:none;background:linear-gradient(to bottom,rgba(248,250,252,0),#f8fafc)}
-    .result-card{position:relative;overflow:hidden;background-color:rgba(255,255,255,.5);backdrop-filter:blur(4px);background-image:radial-gradient(circle at 20% 30%,rgba(173,216,230,.4),transparent 60%)}
-    .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:7rem;font-weight:900;font-family:'Lobster',cursive;color:rgba(15,23,42,.15);pointer-events:none;text-transform:uppercase}
+    .result-card{position:relative;overflow:hidden;background-color:rgba(255,255,255,.3);backdrop-filter:blur(4px)}
+    .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:clamp(5rem,12vw,10rem);font-weight:900;font-family:'UnifrakturCook',cursive;color:rgba(15,23,42,.3);pointer-events:none;text-transform:uppercase}
     .rate{transition:color .2s}
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ispahani Public School & College</title>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+Bengali:wght@400;600;700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Lobster&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
@@ -148,12 +148,12 @@
         <article class="card result-card p-6" data-label="SSC">
           <div class="flex justify-between text-4xl font-extrabold">
             <div class="flex flex-col items-center flex-1">
-              <div class="flex items-baseline"><span class="rate text-yellow-500 text-6xl" data-count="100">0</span><span class="text-3xl">%</span></div>
-              <span class="mt-2 text-base font-semibold">Pass</span>
+              <span class="mb-2 text-lg font-bold">Pass</span>
+              <div class="flex items-baseline"><span class="rate text-red-700 text-6xl" data-count="100">0</span><span class="text-3xl">%</span></div>
             </div>
             <div class="flex flex-col items-center flex-1">
-              <div class="flex items-baseline"><span class="rate text-yellow-500 text-6xl" data-count="80">0</span><span class="text-3xl">%</span></div>
-              <span class="mt-2 text-base font-semibold">GPA 5</span>
+              <span class="mb-2 text-lg font-bold">GPA 5</span>
+              <div class="flex items-baseline"><span class="rate text-green-700 text-6xl" data-count="80">0</span><span class="text-3xl">%</span></div>
             </div>
           </div>
           <p class="mt-4 text-center text-sm">in last <strong>5 years</strong></p>
@@ -161,12 +161,12 @@
         <article class="card result-card p-6" data-label="HSC">
           <div class="flex justify-between text-4xl font-extrabold">
             <div class="flex flex-col items-center flex-1">
-              <div class="flex items-baseline"><span class="rate text-yellow-500 text-6xl" data-count="100">0</span><span class="text-3xl">%</span></div>
-              <span class="mt-2 text-base font-semibold">Pass</span>
+              <span class="mb-2 text-lg font-bold">Pass</span>
+              <div class="flex items-baseline"><span class="rate text-red-700 text-6xl" data-count="100">0</span><span class="text-3xl">%</span></div>
             </div>
             <div class="flex flex-col items-center flex-1">
-              <div class="flex items-baseline"><span class="rate text-yellow-500 text-6xl" data-count="70">0</span><span class="text-3xl">%</span></div>
-              <span class="mt-2 text-base font-semibold">GPA 5</span>
+              <span class="mb-2 text-lg font-bold">GPA 5</span>
+              <div class="flex items-baseline"><span class="rate text-green-700 text-6xl" data-count="70">0</span><span class="text-3xl">%</span></div>
             </div>
           </div>
           <p class="mt-4 text-center text-sm">in last <strong>5 years</strong></p>


### PR DESCRIPTION
## Summary
- Replace cursive SSC/HSC labels with bold UnifrakturCook font and remove pastel backgrounds
- Move Pass/GPA 5 labels above percentages and color metrics red/green for contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b0f259c8832bb855779a91ca897c