### PR TITLE
Revamp result cards and celebration effect

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -102,10 +102,10 @@
     .nav-btn.login:hover,.nav-btn.login:focus{opacity:.9}
     .mlink.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center;justify-content:center}
     .fade-bottom{position:absolute;bottom:0;left:0;width:100%;height:50%;pointer-events:none;background:linear-gradient(to bottom,rgba(248,250,252,0),#f8fafc)}
-    .result-card{position:relative;overflow:hidden;background-color:rgba(255,255,255,.3);backdrop-filter:blur(4px)}
-    .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:clamp(5rem,12vw,10rem);font-weight:900;font-family:'UnifrakturCook',cursive;color:rgba(15,23,42,.3);pointer-events:none;text-transform:uppercase}
+    .result-card{position:relative;overflow:hidden;background-color:rgba(255,255,255,.3);backdrop-filter:blur(4px);min-height:12rem}
+    .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:clamp(8rem,20vw,18rem);font-weight:900;font-family:'UnifrakturCook',cursive;letter-spacing:.5rem;color:rgba(15,23,42,.1);pointer-events:none;text-transform:uppercase}
     .rate{transition:color .2s}
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
-    .confetti{position:absolute;top:0;font-size:1.25rem;animation:confetti 1.5s linear forwards;pointer-events:none}
-    @keyframes confetti{to{transform:translateY(150%) rotate(720deg);opacity:0}}
+    .streamer{position:fixed;width:4px;height:30px;background:var(--color);animation:streamer 2s linear forwards;opacity:.8;top:0}
+    @keyframes streamer{to{transform:translateY(100vh) rotate(720deg);opacity:0}}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -317,14 +317,21 @@ function initCommon(){
   function launchConfetti(el){
     const card=el.closest('.result-card');
     if(!card) return;
-    for(let i=0;i<12;i++){
+    const rect=card.getBoundingClientRect();
+    for(let i=0;i<20;i++){
       const s=document.createElement('span');
-      s.className='confetti';
-      s.textContent='🎉';
-      s.style.left=Math.random()*100+'%';
-      card.appendChild(s);
-      setTimeout(()=>s.remove(),1500);
+      s.className='streamer';
+      s.style.left=rect.left+Math.random()*rect.width+'px';
+      s.style.top=rect.top+'px';
+      s.style.setProperty('--color',randomColor());
+      document.body.appendChild(s);
+      setTimeout(()=>s.remove(),2000);
     }
+  }
+
+  function randomColor(){
+    const colors=['#f56565','#48bb78','#4299e1','#ed8936','#9f7aea','#f6e05e'];
+    return colors[Math.floor(Math.random()*colors.length)];
   }
   document.querySelectorAll('.strip.loop').forEach(strip=>{
     const kids=[...strip.children];


### PR DESCRIPTION
## Summary
- Enlarge SSC/HSC background labels and lighten overlay for cleaner look
- Replace emoji confetti with viewport-spanning colorful streamers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b31a8c28832b937715c094e8d2c9