### PR TITLE
Refine result card typography and confetti

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -103,9 +103,8 @@
     .mlink.login{background:linear-gradient(135deg,var(--brand-green),var(--brand-red));color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center;justify-content:center}
     .fade-bottom{position:absolute;bottom:0;left:0;width:100%;height:50%;pointer-events:none;background:linear-gradient(to bottom,rgba(248,250,252,0),#f8fafc)}
     .result-card{position:relative;overflow:hidden;background-color:rgba(255,255,255,.3);backdrop-filter:blur(4px);min-height:12rem}
-    .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:clamp(8rem,20vw,18rem);font-weight:900;font-family:'UnifrakturCook',cursive;letter-spacing:.5rem;color:rgba(15,23,42,.1);pointer-events:none;text-transform:uppercase}
+    .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:clamp(7rem,18vw,16rem);font-weight:900;font-family:'Poppins',sans-serif;letter-spacing:.5rem;color:rgba(15,23,42,.1);pointer-events:none;text-transform:uppercase}
     .rate{transition:color .2s}
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
-    .streamer{position:fixed;width:4px;height:30px;background:var(--color);animation:streamer 2s linear forwards;opacity:.8;top:0}
-    @keyframes streamer{to{transform:translateY(100vh) rotate(720deg);opacity:0}}
+    .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:center}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -318,14 +318,21 @@ function initCommon(){
     const card=el.closest('.result-card');
     if(!card) return;
     const rect=card.getBoundingClientRect();
+    const originX=rect.left+rect.width/2;
+    const originY=rect.top+rect.height/2;
     for(let i=0;i<20;i++){
       const s=document.createElement('span');
       s.className='streamer';
-      s.style.left=rect.left+Math.random()*rect.width+'px';
-      s.style.top=rect.top+'px';
+      s.style.left=originX+'px';
+      s.style.top=originY+'px';
       s.style.setProperty('--color',randomColor());
       document.body.appendChild(s);
-      setTimeout(()=>s.remove(),2000);
+      const dx=Math.random()*200-100;
+      const up=150+Math.random()*50;
+      gsap.to(s,{x:dx,y:-up,rotation:Math.random()*180-90,duration:.6,ease:'power2.out',onComplete:()=>{
+        gsap.to(s,{y:"+="+(up+600),x:"+="+(dx*.2),rotation:"+=720",duration:1.5,ease:'power2.in',onComplete:()=>s.remove()});
+      }});
+      gsap.to(s,{rotation:()=>Math.random()*30-15,repeat:-1,yoyo:true,duration:.2});
     }
   }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Ispahani Public School & College</title>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+Bengali:wght@400;600;700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>


### PR DESCRIPTION
## Summary
- Switch SSC/HSC result card overlay to Poppins font and make it slightly smaller
- Rework celebration streamers with GSAP physics for a more natural spread
- Simplify streamer CSS to support new animations

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b4ab3f44832bbe4026335800716f