### PR TITLE
Add smooth confetti streamers

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -107,4 +107,4 @@
     .rate{transition:color .2s}
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
-    .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:center;border-radius:2px;will-change:transform}
+    .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:top center;border-radius:2px;will-change:transform}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -1,3 +1,4 @@
+gsap.registerPlugin(MotionPathPlugin);
 document.addEventListener('DOMContentLoaded',initCommon);
 
 function initCommon(){
@@ -327,17 +328,18 @@ function initCommon(){
       s.style.top=originY+'px';
       s.style.setProperty('--color',randomColor());
       document.body.appendChild(s);
-      const angle=Math.random()*Math.PI; // spread left to right while going upward
+      const angle=Math.random()*Math.PI*2; // spread in all directions
       const dist=120+Math.random()*180;
       const dx=Math.cos(angle)*dist;
-      const dy=-Math.sin(angle)*dist;
-      const bend=(Math.random()*60-30);
-      const midX=dx/2+bend;
-      const midY=dy/2-(40+Math.random()*40);
-      const tl=gsap.timeline({onComplete:()=>s.remove()});
-      tl.to(s,{x:midX,y:midY,rotation:Math.random()*180-90,duration:.5,ease:'power2.out'})
-        .to(s,{x:dx,y:dy,duration:.4,ease:'sine.inOut'})
-        .to(s,{x:dx+bend*0.5,y:dy+600,rotation:"+=720",duration:1.2,ease:'power2.in'});
+      const dy=Math.sin(angle)*dist;
+      const bend=Math.random()*60-30;
+      const path=[
+        {x:0,y:0},
+        {x:dx/2+bend,y:dy/2-(40+Math.random()*40)},
+        {x:dx,y:dy},
+        {x:dx+bend*0.5,y:dy+600}
+      ];
+      gsap.to(s,{motionPath:{path,curviness:1.25},duration:2,ease:'power1.inOut',onComplete:()=>s.remove()});
       gsap.to(s,{rotation:()=>Math.random()*60-30,skewX:15,skewY:-15,repeat:-1,yoyo:true,duration:.25,ease:'sine.inOut'});
     }
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="components/common.css"/>
   </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">

--- a/frontend/pages/clubs.html
+++ b/frontend/pages/clubs.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="../components/common.css"/>
   </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">

--- a/frontend/pages/facilities.html
+++ b/frontend/pages/facilities.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="../components/common.css"/>
 </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">

--- a/frontend/pages/governing.html
+++ b/frontend/pages/governing.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="../components/common.css"/>
 </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">

--- a/frontend/pages/notice.html
+++ b/frontend/pages/notice.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="../components/common.css"/>
 </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">

--- a/frontend/pages/staff-quarter.html
+++ b/frontend/pages/staff-quarter.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="../components/common.css"/>
 </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">

--- a/frontend/pages/staffs.html
+++ b/frontend/pages/staffs.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="../components/common.css"/>
 </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">

--- a/frontend/pages/student-galleries.html
+++ b/frontend/pages/student-galleries.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="../components/common.css"/>
 </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">

--- a/frontend/pages/teachers.html
+++ b/frontend/pages/teachers.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="../components/common.css"/>
 </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">

--- a/frontend/pages/transport.html
+++ b/frontend/pages/transport.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
   <link rel="stylesheet" href="../components/common.css"/>
 </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">


### PR DESCRIPTION
## Summary
- Register GSAP MotionPathPlugin and animate confetti streamers along curved paths for smoother spread
- Pivot streamers from their top edge and add MotionPath plugin scripts to all pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ba6c1194832b87b59eb1caa89c37