### PR TITLE
Add 3D rotating gallery carousel

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -108,18 +108,6 @@
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
     .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:top center;border-radius:2px;will-change:transform}
-    .circular-gallery{position:relative;width:20rem;height:20rem;margin:0 auto;animation:spin 20s linear infinite}
-    .circular-gallery img{position:absolute;top:50%;left:50%;width:5rem;height:5rem;margin:-2.5rem;border-radius:.75rem;object-fit:cover}
-    .circular-gallery img:nth-child(1){transform:rotate(0deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(2){transform:rotate(30deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(3){transform:rotate(60deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(4){transform:rotate(90deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(5){transform:rotate(120deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(6){transform:rotate(150deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(7){transform:rotate(180deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(8){transform:rotate(210deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(9){transform:rotate(240deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(10){transform:rotate(270deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(11){transform:rotate(300deg) translate(0,-8rem)}
-    .circular-gallery img:nth-child(12){transform:rotate(330deg) translate(0,-8rem)}
-    @keyframes spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+    .circular-gallery{position:relative;width:100%;max-width:28rem;height:16rem;margin:0 auto;perspective:1000px;transform-style:preserve-3d}
+    .circular-gallery img{position:absolute;top:50%;left:50%;width:10rem;height:6rem;object-fit:cover;border-radius:.75rem;transform-style:preserve-3d;transition:transform .5s,opacity .5s,filter .5s}
+    @media(max-width:640px){.circular-gallery{height:14rem}.circular-gallery img{width:8rem;height:5rem}}

--- a/frontend/components/gallery.js
+++ b/frontend/components/gallery.js
@@ -1,0 +1,34 @@
+(document => {
+  document.addEventListener('DOMContentLoaded', () => {
+    const wrap = document.querySelector('.circular-gallery');
+    if (!wrap) return;
+    const imgs = wrap.querySelectorAll('img');
+    const total = imgs.length;
+    if (!total) return;
+    const step = 360 / total;
+    let angle = 0;
+    let radius = wrap.offsetWidth / 2.5;
+
+    const updateRadius = () => {
+      radius = wrap.offsetWidth / 2.5;
+    };
+    window.addEventListener('resize', updateRadius);
+
+    const render = () => {
+      imgs.forEach((img, i) => {
+        const theta = i * step + angle;
+        const cos = Math.cos(theta * Math.PI / 180);
+        const factor = (cos + 1) / 2; // 0 at back, 1 at front
+        const scale = 0.6 + 0.4 * factor;
+        img.style.transform = `translate(-50%, -50%) rotateY(${theta}deg) translateZ(${radius}px) scale(${scale})`;
+        img.style.opacity = (0.3 + 0.7 * factor).toString();
+        img.style.filter = `contrast(${0.6 + 0.4 * factor})`;
+        img.style.zIndex = Math.round(factor * 1000);
+      });
+      angle -= 0.3; // rotate right to left
+      requestAnimationFrame(render);
+    };
+
+    render();
+  });
+})(document);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -313,6 +313,7 @@
   </footer>
     <script src="components/student-galleries.js" defer></script>
     <script src="components/teachers.js" defer></script>
+    <script src="components/gallery.js" defer></script>
     <script src="components/common.js" defer></script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- replace old 2D gallery with a responsive 3D carousel
- add JavaScript to animate rotation, scaling, and contrast for center image emphasis
- wire new gallery script into the index page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c60100a4832b99e11fc8c226a68f