### PR TITLE
feat: revamp gallery carousel

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -108,6 +108,6 @@
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
     .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:top center;border-radius:2px;will-change:transform}
-    .circular-gallery{position:relative;width:100%;max-width:28rem;height:16rem;margin:0 auto;perspective:1000px;transform-style:preserve-3d}
-    .circular-gallery img{position:absolute;top:50%;left:50%;width:10rem;height:6rem;object-fit:cover;border-radius:.75rem;transform-style:preserve-3d;transition:transform .5s,opacity .5s,filter .5s}
-    @media(max-width:640px){.circular-gallery{height:14rem}.circular-gallery img{width:8rem;height:5rem}}
+    .circular-gallery{position:relative;width:100%;max-width:40rem;height:20rem;margin:0 auto;overflow:hidden}
+    .circular-gallery img{position:absolute;top:50%;left:50%;width:12rem;height:8rem;object-fit:cover;border:4px solid #fff;border-radius:.75rem;transition:transform .5s,opacity .5s,filter .5s}
+    @media(max-width:640px){.circular-gallery{height:16rem}.circular-gallery img{width:9rem;height:6rem}}

--- a/frontend/components/gallery.js
+++ b/frontend/components/gallery.js
@@ -2,33 +2,65 @@
   document.addEventListener('DOMContentLoaded', () => {
     const wrap = document.querySelector('.circular-gallery');
     if (!wrap) return;
-    const imgs = wrap.querySelectorAll('img');
-    const total = imgs.length;
-    if (!total) return;
-    const step = 360 / total;
-    let angle = 0;
-    let radius = wrap.offsetWidth / 2.5;
-
-    const updateRadius = () => {
-      radius = wrap.offsetWidth / 2.5;
-    };
-    window.addEventListener('resize', updateRadius);
+    const imgs = Array.from(wrap.querySelectorAll('img'));
+    if (!imgs.length) return;
+    let current = 0;
 
     const render = () => {
+      const isMobile = window.innerWidth < 640;
+      const max = isMobile ? 1 : 2; // visible neighbors on each side
       imgs.forEach((img, i) => {
-        const theta = i * step + angle;
-        const cos = Math.cos(theta * Math.PI / 180);
-        const factor = (cos + 1) / 2; // 0 at back, 1 at front
-        const scale = 0.6 + 0.4 * factor;
-        img.style.transform = `translate(-50%, -50%) rotateY(${theta}deg) translateZ(${radius}px) scale(${scale})`;
-        img.style.opacity = (0.3 + 0.7 * factor).toString();
-        img.style.filter = `contrast(${0.6 + 0.4 * factor})`;
-        img.style.zIndex = Math.round(factor * 1000);
+        const diff = i - current;
+        const ad = Math.abs(diff);
+        if (ad > max) {
+          img.style.opacity = '0';
+          img.style.transform = `translate(-50%, -50%) translateX(${diff * 100}%) scale(0.4)`;
+          img.style.pointerEvents = 'none';
+        } else {
+          const scale = 1 - 0.2 * ad;
+          const contrast = 1 - 0.3 * ad;
+          const offsetY = isMobile ? ad * 10 : 0;
+          img.style.opacity = '1';
+          img.style.transform = `translate(-50%, -50%) translateX(${diff * 100}%) translateY(${offsetY}px) scale(${scale})`;
+          img.style.filter = `contrast(${contrast})`;
+          img.style.zIndex = `${10 - ad}`;
+          img.style.pointerEvents = 'auto';
+        }
       });
-      angle -= 0.3; // rotate right to left
-      requestAnimationFrame(render);
     };
 
+    const next = () => {
+      current = (current + 1) % imgs.length;
+      render();
+    };
+    const prev = () => {
+      current = (current - 1 + imgs.length) % imgs.length;
+      render();
+    };
+
+    let auto = setInterval(next, 3000);
+
+    wrap.addEventListener('click', e => {
+      const rect = wrap.getBoundingClientRect();
+      if (e.clientX - rect.left < rect.width / 2) {
+        prev();
+      } else {
+        next();
+      }
+      clearInterval(auto);
+      auto = setInterval(next, 3000);
+    });
+
+    wrap.addEventListener('wheel', e => {
+      e.preventDefault();
+      if (e.deltaY > 0) next();
+      else prev();
+      clearInterval(auto);
+      auto = setInterval(next, 3000);
+    });
+
+    window.addEventListener('resize', render);
     render();
   });
 })(document);
+


### PR DESCRIPTION
## Summary
- highlight center image in gallery and fade side items
- enlarge gallery thumbnails with border and responsive sizing
- add manual click/wheel controls and slower autoplay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c844b990832b8862a0afcfc4cd13