### PR TITLE
feat: add carousel gallery

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -108,5 +108,9 @@
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
     .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:top center;border-radius:2px;will-change:transform}
-      .gallery-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem}
-      .gallery-grid img{width:100%;height:auto;aspect-ratio:4/3;object-fit:cover;border-radius:.75rem}
+      #gallery .carousel{position:relative;height:260px;margin:0 auto;overflow:hidden}
+      #gallery .carousel img{position:absolute;top:50%;left:50%;width:320px;height:200px;object-fit:cover;border-radius:.75rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transform:translate(-50%,-50%);transition:transform .4s,opacity .4s,filter .4s}
+      #gallery .carousel button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(255,255,255,.7);border:none;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer}
+      #gallery .carousel button:hover{background:rgba(255,255,255,.9)}
+      #gallery .carousel .gprev{left:0}
+      #gallery .carousel .gnext{right:0}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -385,4 +385,51 @@ function initCommon(){
   gsap.from('#masthead',{y:-60,opacity:0,duration:.6});
   const revealItems=document.querySelectorAll('.section,.card');
   const io2=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){gsap.to(e.target,{opacity:1,y:0,duration:.6});io2.unobserve(e.target);}})},{threshold:.2});
-  revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});}
+  revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});
+
+  const gc=document.getElementById('galleryCarousel');
+  if(gc){
+    const imgs=Array.from(gc.querySelectorAll('img'));
+    let idx=0;
+    const update=()=>{
+      imgs.forEach((img,i)=>{
+        const diff=(i-idx+imgs.length)%imgs.length;
+        img.style.transition='transform .4s,opacity .4s,filter .4s';
+        if(diff===0){
+          img.style.transform='translate(-50%,-50%) scale(1)';
+          img.style.opacity='1';
+          img.style.filter='none';
+          img.style.zIndex='3';
+        }else if(diff===1){
+          img.style.transform='translate(-50%,-50%) translateX(300px) scale(.8)';
+          img.style.opacity='.8';
+          img.style.filter='none';
+          img.style.zIndex='2';
+        }else if(diff===2){
+          img.style.transform='translate(-50%,-50%) translateX(560px) scale(.6)';
+          img.style.opacity='.3';
+          img.style.filter='grayscale(1)';
+          img.style.zIndex='1';
+        }else if(diff===imgs.length-1){
+          img.style.transform='translate(-50%,-50%) translateX(-300px) scale(.8)';
+          img.style.opacity='.8';
+          img.style.filter='none';
+          img.style.zIndex='2';
+        }else if(diff===imgs.length-2){
+          img.style.transform='translate(-50%,-50%) translateX(-560px) scale(.6)';
+          img.style.opacity='.3';
+          img.style.filter='grayscale(1)';
+          img.style.zIndex='1';
+        }else{
+          img.style.transform='translate(-50%,-50%) scale(.4)';
+          img.style.opacity='0';
+          img.style.filter='none';
+          img.style.zIndex='0';
+        }
+      });
+    };
+    gc.querySelector('.gprev').addEventListener('click',()=>{idx=(idx-1+imgs.length)%imgs.length;update();});
+    gc.querySelector('.gnext').addEventListener('click',()=>{idx=(idx+1)%imgs.length;update();});
+    update();
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -264,7 +264,9 @@
 <section id="gallery" class="section">
   <div class="wrap">
     <div class="head"><h2>Gallery</h2></div>
-    <div class="gallery-grid">
+    <div class="carousel" id="galleryCarousel">
+      <button class="gprev" aria-label="Previous"><i class="fa-solid fa-chevron-left"></i></button>
+      <button class="gnext" aria-label="Next"><i class="fa-solid fa-chevron-right"></i></button>
       <img loading="lazy" decoding="async" src="assets/galleries/gallery-1.jpg" alt="Annual Day">
       <img loading="lazy" decoding="async" src="assets/galleries/gallery-2.jpg" alt="Science Fair">
       <img loading="lazy" decoding="async" src="assets/galleries/gallery-3.jpg" alt="Cultural Fest">


### PR DESCRIPTION
## Summary
- add carousel-based gallery with side previews and navigation buttons
- style gallery carousel layout and controls
- implement JavaScript to handle carousel transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3cc94ae6c832b98dd891625724c0f