### PR TITLE
Enlarge gallery images and update carousel behaviour

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -108,8 +108,8 @@
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
     .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:top center;border-radius:2px;will-change:transform}
-      #gallery .carousel{position:relative;height:280px;margin:0 auto;overflow:hidden}
-      #gallery .carousel img{position:absolute;top:50%;left:50%;width:360px;height:225px;object-fit:cover;border-radius:.75rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transform:translate(-50%,-50%);transition:transform .4s,opacity .4s,filter .4s}
+      #gallery .carousel{position:relative;width:calc(100% - 80px);aspect-ratio:16/10;margin:0 auto;overflow:hidden}
+      #gallery .carousel img{position:absolute;top:50%;left:50%;width:100%;height:100%;object-fit:cover;border-radius:.75rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transform:translate(-50%,-50%);transition:transform .4s,opacity .4s,filter .4s}
       #gallery .carousel button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(255,255,255,.7);border:none;width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer}
       #gallery .carousel button:hover{background:rgba(255,255,255,.9)}
       #gallery .carousel .gprev{left:0}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -391,7 +391,9 @@ function initCommon(){
   if(gc){
     const imgs=Array.from(gc.querySelectorAll('img'));
     let idx=0;
+    const getOffset=()=>imgs[0].clientWidth-60;
     const update=()=>{
+      const offset=getOffset();
       imgs.forEach((img,i)=>{
         const diff=(i-idx+imgs.length)%imgs.length;
         img.style.transition='transform .4s,opacity .4s,filter .4s';
@@ -401,12 +403,12 @@ function initCommon(){
           img.style.filter='none';
           img.style.zIndex='3';
         }else if(diff===1){
-          img.style.transform='translate(-50%,-50%) translateX(300px) scale(.8)';
+          img.style.transform=`translate(-50%,-50%) translateX(${offset}px) scale(.8)`;
           img.style.opacity='.5';
           img.style.filter='grayscale(1)';
           img.style.zIndex='2';
         }else if(diff===imgs.length-1){
-          img.style.transform='translate(-50%,-50%) translateX(-300px) scale(.8)';
+          img.style.transform=`translate(-50%,-50%) translateX(-${offset}px) scale(.8)`;
           img.style.opacity='.5';
           img.style.filter='grayscale(1)';
           img.style.zIndex='2';
@@ -424,6 +426,7 @@ function initCommon(){
     const reset=()=>{clearInterval(timer);timer=setInterval(next,4000);};
     gc.querySelector('.gprev').addEventListener('click',()=>{prev();reset();});
     gc.querySelector('.gnext').addEventListener('click',()=>{next();reset();});
+    window.addEventListener('resize',update);
     gc.addEventListener('pointerdown',e=>{
       const sx=e.clientX;
       const onUp=ev=>{


### PR DESCRIPTION
## Summary
- Expand gallery carousel and images to occupy nearly full width
- Compute carousel translation offsets based on image width and update on window resize

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d2aa9ab8832b9ea00e281dd07dc3