### PR TITLE
feat: widen mobile gallery margins

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -90,7 +90,7 @@
     .shape.square{background:linear-gradient(135deg,var(--brand-red),#fff)}
     .shape.triangle{background:linear-gradient(135deg,#fff,var(--brand-green));clip-path:polygon(50% 0,0 100%,100% 100%)}
     @keyframes drift{from{transform:translateY(0) rotate(0deg)}to{transform:translateY(-40px) rotate(360deg)}}
-    @media(max-width:640px){.strip img{width:260px;height:160px}.brand img{width:48px;height:48px}.btext strong{font-size:.9rem}.btext span{font-size:.65rem}.counters{grid-template-columns:1fr}}
+    @media(max-width:640px){.strip img{width:260px;height:160px}.brand img{width:48px;height:48px}.btext strong{font-size:.9rem}.btext span{font-size:.65rem}.counters{grid-template-columns:1fr}#gallery .carousel{width:calc(100% - 120px)}}
     .club-hero{padding:3rem 0 2rem;margin-top:0;text-align:center;background:rgba(255,255,255,.5);backdrop-filter:blur(4px)}
     .club-hero h1{font-size:clamp(2.5rem,6vw,4rem);font-weight:900}
     .club-card{display:grid;gap:1rem;align-items:center}


### PR DESCRIPTION
## Summary
- Show side-image previews in mobile gallery by expanding margins

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d51e7550832b9e5f8e9e8834b409