### PR TITLE
Add edge fade for gallery carousel

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -109,6 +109,9 @@
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
     .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:top center;border-radius:2px;will-change:transform}
       #gallery .carousel{position:relative;width:100%;max-width:900px;aspect-ratio:16/9;margin:0 auto;overflow:hidden}
+      #gallery .carousel::before,#gallery .carousel::after{content:"";position:absolute;top:0;bottom:0;width:clamp(40px,10vw,80px);pointer-events:none;z-index:4}
+      #gallery .carousel::before{left:0;background:linear-gradient(to right,#f8fafc,rgba(248,250,252,0))}
+      #gallery .carousel::after{right:0;background:linear-gradient(to left,#f8fafc,rgba(248,250,252,0))}
       #gallery .carousel img{position:absolute;top:50%;left:50%;width:100%;height:100%;object-fit:cover;border-radius:.75rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transform:translate(-50%,-50%);transition:transform .4s,opacity .4s,filter .4s}
       #gallery .carousel button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(255,255,255,.8);border:none;width:44px;height:44px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;z-index:10;color:#0f172a}
       #gallery .carousel button:hover{background:rgba(255,255,255,.95)}


### PR DESCRIPTION
## Summary
- overlay gradients on gallery carousel edges for fading preview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d826b050832b9fd29f2dff9b1b6d