### PR TITLE
Adjust gallery carousel for partial side previews

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -109,7 +109,7 @@
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
     .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:top center;border-radius:2px;will-change:transform}
       #gallery .carousel{position:relative;width:100%;max-width:900px;aspect-ratio:16/9;margin:0 auto;overflow:hidden}
-      #gallery .carousel::before,#gallery .carousel::after{content:"";position:absolute;top:0;bottom:0;width:clamp(40px,10vw,80px);pointer-events:none;z-index:4}
+      #gallery .carousel::before,#gallery .carousel::after{content:"";position:absolute;top:0;bottom:0;width:10%;pointer-events:none;z-index:4}
       #gallery .carousel::before{left:0;background:linear-gradient(to right,#f8fafc,rgba(248,250,252,0))}
       #gallery .carousel::after{right:0;background:linear-gradient(to left,#f8fafc,rgba(248,250,252,0))}
       #gallery .carousel img{position:absolute;top:50%;left:50%;width:100%;height:100%;object-fit:cover;border-radius:.75rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transform:translate(-50%,-50%);transition:transform .4s,opacity .4s,filter .4s}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -391,7 +391,10 @@ function initCommon(){
   if(gc){
     const imgs=Array.from(gc.querySelectorAll('img'));
     let idx=0;
-    const getOffset=()=>imgs[0].clientWidth*0.5+20;
+    const getOffset=()=>{
+      const w=imgs[0].clientWidth;
+      return (window.innerWidth<640?w*0.9:w*0.5+20);
+    };
     const update=()=>{
       const offset=getOffset();
       imgs.forEach((img,i)=>{


### PR DESCRIPTION
## Summary
- Adjust carousel edge fade to span 10% width.
- Offset side images further on mobile to show only a 10% preview.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d9dea410832bb3ff8608d89d96ce