### PR TITLE
Fix mobile gallery preview spacing

### DIFF
--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -393,7 +393,7 @@ function initCommon(){
     let idx=0;
     const getOffset=()=>{
       const w=imgs[0].clientWidth;
-      return (window.innerWidth<640?w*0.9:w*0.5+20);
+      return (window.innerWidth<640?w*0.55:w*0.5+20);
     };
     const update=()=>{
       const offset=getOffset();


### PR DESCRIPTION
## Summary
- Adjust gallery carousel offset calculation to keep side images visible on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3de7d9f7c832bb29fc48697d8cd16