### PR TITLE
feat: add responsive auto-scrolling gallery

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -126,8 +126,7 @@
           #gallery .carousel .gprev{top:10px;left:50%}
           #gallery .carousel .gnext{bottom:10px;left:50%;right:auto}
         }
-#gallery .gallery-grid{display:flex;flex-direction:column;gap:0;max-width:900px;margin:0 auto;height:80vw;max-height:600px;overflow:hidden;transition:transform .5s}
-#gallery .gallery-grid.slide{transform:translateY(-33.333%)}
-#gallery .gallery-grid img{flex:1;width:100%;height:100%;object-fit:cover;border-radius:.75rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transition:transform .5s,opacity .5s,filter .5s}
-#gallery .gallery-grid img:nth-child(2){transform:scale(1.1);opacity:1;filter:none;z-index:1}
-#gallery .gallery-grid img:not(:nth-child(2)){transform:scale(.8);opacity:.6;filter:grayscale(1)}
+#gallery .gallery-row{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(250px,1fr);gap:.75rem;max-width:900px;margin:0 auto;overflow-x:auto;scroll-snap-type:x mandatory;scrollbar-width:none}
+#gallery .gallery-row::-webkit-scrollbar{display:none}
+#gallery .gallery-row img{width:100%;height:200px;object-fit:cover;border-radius:.75rem;box-shadow:0 6px 16px rgba(2,6,23,.08);scroll-snap-align:start}
+@media(max-width:640px){#gallery .gallery-row{grid-auto-columns:70%}#gallery .gallery-row img{height:160px}}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -387,8 +387,8 @@ function initCommon(){
   const io2=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){gsap.to(e.target,{opacity:1,y:0,duration:.6});io2.unobserve(e.target);}})},{threshold:.2});
   revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});
 
-  const gg=document.getElementById('galleryGrid');
-  if(gg){
+  const gr=document.getElementById('galleryRow');
+  if(gr){
     const images=[
       'assets/galleries/gallery-1.jpg',
       'assets/galleries/gallery-2.jpg',
@@ -403,24 +403,22 @@ function initCommon(){
       'assets/galleries/gallery-11.jpg',
       'assets/galleries/gallery-12.jpg'
     ];
-    const slots=Array.from(gg.querySelectorAll('img'));
-    let idx=0; // index of the first (top) image in the array
-    const setImages=()=>{
-      for(let i=0;i<slots.length;i++){
-        slots[i].src=images[(idx+i)%images.length];
+    images.forEach(src=>{
+      const img=document.createElement('img');
+      img.loading='lazy';
+      img.decoding='async';
+      img.alt='Gallery image';
+      img.src=src;
+      gr.appendChild(img);
+    });
+    const autoScroll=()=>{
+      const max=gr.scrollWidth-gr.clientWidth;
+      if(gr.scrollLeft>=max){
+        gr.scrollTo({left:0,behavior:'smooth'});
+      }else{
+        gr.scrollBy({left:gr.clientWidth,behavior:'smooth'});
       }
     };
-    setImages();
-    const cycle=()=>{
-      gg.classList.add('slide');
-      setTimeout(()=>{
-        gg.classList.remove('slide');
-        gg.appendChild(slots[0]);
-        slots.push(slots.shift());
-        idx=(idx+1)%images.length;
-        slots[2].src=images[(idx+2)%images.length];
-      },500);
-    };
-    setInterval(cycle,4000);
+    setInterval(autoScroll,4000);
   }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -264,11 +264,7 @@
 <section id="gallery" class="section">
   <div class="wrap">
     <div class="head"><h2>Gallery</h2></div>
-    <div class="gallery-grid" id="galleryGrid">
-      <img loading="lazy" decoding="async" alt="Gallery image">
-      <img loading="lazy" decoding="async" alt="Gallery image">
-      <img loading="lazy" decoding="async" alt="Gallery image">
-    </div>
+    <div class="gallery-row" id="galleryRow"></div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Replace gallery with horizontal layout that auto-scrolls through all images
- Style gallery for responsive fixed-size grid on desktop and mobile
- Populate gallery dynamically with JS for smooth scroll

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f00a2c2c832b8d685d1952fa7724