### PR TITLE
Increase gallery curvature

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -134,7 +134,7 @@
           #gallery .carousel .gprev{top:10px;left:50%}
           #gallery .carousel .gnext{bottom:10px;left:50%;right:auto}
         }
-#gallery .gallery-row{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(250px,1fr);gap:1rem;max-width:900px;margin:0 auto;overflow:hidden;scrollbar-width:none;perspective:1000px;transform-style:preserve-3d}
+#gallery .gallery-row{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(250px,1fr);gap:1rem;max-width:900px;margin:0 auto;overflow:hidden;scrollbar-width:none;perspective:1000px;transform-style:preserve-3d;border-radius:1.5rem}
 #gallery .gallery-row::-webkit-scrollbar{display:none}
-#gallery .gallery-row img{width:100%;height:240px;object-fit:cover;border-radius:.75rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transition:transform .3s;transform-origin:center}
+#gallery .gallery-row img{width:100%;height:240px;object-fit:cover;border-radius:1.5rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transition:transform .3s;transform-origin:center}
 @media(max-width:640px){#gallery .gallery-row{grid-auto-columns:70%;gap:.75rem}#gallery .gallery-row img{height:160px}}

--- a/frontend/components/student-galleries.js
+++ b/frontend/components/student-galleries.js
@@ -91,7 +91,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     files.forEach(f => {
       const card = document.createElement('div');
-      card.className = 'video-card aspect-video overflow-hidden rounded-xl shadow-lg border border-gray-200 transition-transform hover:-translate-y-1 hover:shadow-2xl bg-black';
+      card.className = 'video-card aspect-video overflow-hidden rounded-3xl shadow-lg border border-gray-200 transition-transform hover:-translate-y-1 hover:shadow-2xl bg-black';
 
       const video = document.createElement('video');
       video.src = root + 'assets/student-galleries/' + f;


### PR DESCRIPTION
## Summary
- Round gallery grid container and images with larger 1.5rem border radius
- Soften student video card edges via `rounded-3xl`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fcafd408832b93f71e5d49bdc1fb