### PR TITLE
Increase mobile gallery image height

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -141,4 +141,4 @@
 #gallery .gallery-row{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(250px,1fr);gap:1rem;max-width:900px;margin:0 auto;overflow:hidden;scrollbar-width:none;perspective:1000px;transform-style:preserve-3d;border-radius:1.5rem}
 #gallery .gallery-row::-webkit-scrollbar{display:none}
 #gallery .gallery-row img{width:100%;height:240px;object-fit:cover;border-radius:1.5rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transition:transform .3s;transform-origin:center}
-@media(max-width:640px){#gallery .gallery-row{grid-auto-columns:70%;gap:.75rem}#gallery .gallery-row img{height:160px}}
+@media(max-width:640px){#gallery .gallery-row{grid-auto-columns:70%;gap:.75rem}#gallery .gallery-row img{height:200px}}


### PR DESCRIPTION
## Summary
- enlarge gallery row images height on small screens to show larger photos

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c408953270832b856ebde6e261f354