### PR TITLE
Expand gallery row to full width

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -138,7 +138,7 @@
           #gallery .carousel .gprev{top:10px;left:50%}
           #gallery .carousel .gnext{bottom:10px;left:50%;right:auto}
         }
-#gallery .gallery-row{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(360px,1fr);gap:1.5rem;max-width:900px;margin:0 auto;overflow:hidden;scrollbar-width:none;perspective:1000px;transform-style:preserve-3d;border-radius:1.5rem}
+#gallery .gallery-row{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(360px,1fr);gap:1.5rem;width:100%;margin:0 auto;overflow:hidden;scrollbar-width:none;perspective:1000px;transform-style:preserve-3d;border-radius:1.5rem}
 #gallery .gallery-row::-webkit-scrollbar{display:none}
 #gallery .gallery-row img{width:100%;height:270px;object-fit:cover;border-radius:1.5rem;box-shadow:0 6px 16px rgba(2,6,23,.08);transition:transform .3s;transform-origin:center}
 @media(max-width:640px){#gallery .gallery-row{grid-auto-columns:80%;gap:1rem}#gallery .gallery-row img{height:220px}}


### PR DESCRIPTION
## Summary
- Let gallery row span full container width so images fill margins on desktop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c41607cfd8832bb7bcea6cdfebd3af