### PR TITLE
Replace result card streamers with particle confetti

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -119,7 +119,7 @@
     .rate{transition:color .2s}
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
-    .streamer{position:fixed;width:4px;height:30px;background:var(--color);opacity:.8;pointer-events:none;transform-origin:top center;border-radius:2px;will-change:transform}
+    .particle{position:fixed;width:6px;height:6px;background:var(--color);opacity:.9;pointer-events:none;border-radius:50%;will-change:transform}
       #gallery .carousel{position:relative;width:100%;max-width:900px;aspect-ratio:16/9;margin:0 auto;overflow:hidden}
       #gallery .carousel::before,#gallery .carousel::after{content:"";position:absolute;top:0;bottom:0;width:10%;pointer-events:none;z-index:4}
       #gallery .carousel::before{left:0;background:linear-gradient(to right,#f8fafc,rgba(248,250,252,0))}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -326,9 +326,11 @@ function initCommon(){
     const rect=card.getBoundingClientRect();
     const originX=rect.left+rect.width/2;
     const originY=rect.top+rect.height/2;
-    for(let i=0;i<25;i++){
+    for(let i=0;i<120;i++){
       const s=document.createElement('span');
-      s.className='streamer';
+      s.className='particle';
+      const size=4+Math.random()*4;
+      s.style.width=s.style.height=size+'px';
       s.style.left=originX+'px';
       s.style.top=originY+'px';
       s.style.setProperty('--color',randomColor());
@@ -344,14 +346,14 @@ function initCommon(){
         {x:dx,y:dy},
         {x:dx+bend*0.5,y:dy+600}
       ];
-      gsap.to(s,{motionPath:{path,curviness:1.25},duration:2,ease:'power1.inOut',onComplete:()=>s.remove()});
-      gsap.to(s,{rotation:()=>Math.random()*60-30,skewX:15,skewY:-15,repeat:-1,yoyo:true,duration:.25,ease:'sine.inOut'});
+      gsap.to(s,{motionPath:{path,curviness:1.25},duration:3,ease:'power1.inOut',onComplete:()=>s.remove()});
+      gsap.to(s,{rotation:()=>Math.random()*360,repeat:-1,duration:1,ease:'linear'});
     }
   }
 
   function randomColor(){
-    const colors=['#f56565','#48bb78','#4299e1','#ed8936','#9f7aea','#f6e05e'];
-    return colors[Math.floor(Math.random()*colors.length)];
+    const h=Math.floor(Math.random()*360);
+    return `hsl(${h},70%,60%)`;
   }
   document.querySelectorAll('.strip.loop').forEach(strip=>{
     const kids=[...strip.children];


### PR DESCRIPTION
## Summary
- Swap streamer ribbons for small particle confetti in result card celebration
- Generate many colorful particles with random hues and physics-driven motion

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c41a787af4832b8a2e49f68cebef4f