### PR TITLE
Optimize confetti rendering for smoother results

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -118,7 +118,7 @@
     .rate{transition:color .2s}
     .rate.celebrate{animation:yay .8s ease}
     @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
-    .particle{position:fixed;width:6px;height:6px;background:var(--color);opacity:.9;pointer-events:none;border-radius:50%;will-change:transform}
+    .particle{position:fixed;width:6px;height:6px;background:var(--color);opacity:.9;pointer-events:none;border-radius:50%;will-change:transform;transform:translate3d(0,0,0)}
       #gallery .carousel{position:relative;width:100%;max-width:900px;aspect-ratio:16/9;margin:0 auto;overflow:hidden}
       #gallery .carousel::before,#gallery .carousel::after{content:"";position:absolute;top:0;bottom:0;width:10%;pointer-events:none;z-index:4}
       #gallery .carousel::before{left:0;background:linear-gradient(to right,#f8fafc,rgba(248,250,252,0))}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -320,36 +320,43 @@ function initCommon(){
   },{threshold:.2});
   rates.forEach(r=>rateIO.observe(r));
 
-  function launchConfetti(el){
-    const card=el.closest('.result-card');
-    if(!card) return;
-    const rect=card.getBoundingClientRect();
-    const originX=rect.left+rect.width/2;
-    const originY=rect.top+rect.height/2;
-    for(let i=0;i<120;i++){
-      const s=document.createElement('span');
-      s.className='particle';
-      const size=4+Math.random()*4;
-      s.style.width=s.style.height=size+'px';
-      s.style.left=originX+'px';
-      s.style.top=originY+'px';
-      s.style.setProperty('--color',randomColor());
-      document.body.appendChild(s);
-      const angle=Math.random()*Math.PI*2; // spread in all directions
-      const dist=120+Math.random()*180;
-      const dx=Math.cos(angle)*dist;
-      const dy=Math.sin(angle)*dist;
-      const bend=Math.random()*60-30;
-      const path=[
-        {x:0,y:0},
-        {x:dx/2+bend,y:dy/2-(40+Math.random()*40)},
-        {x:dx,y:dy},
-        {x:dx+bend*0.5,y:dy+600}
-      ];
-      gsap.to(s,{motionPath:{path,curviness:1.25},duration:3,ease:'power1.inOut',onComplete:()=>s.remove()});
-      gsap.to(s,{rotation:()=>Math.random()*360,repeat:-1,duration:1,ease:'linear'});
+    function launchConfetti(el){
+      const card=el.closest('.result-card');
+      if(!card) return;
+      const rect=card.getBoundingClientRect();
+      const originX=rect.left+rect.width/2;
+      const originY=rect.top+rect.height/2;
+      const frag=document.createDocumentFragment();
+      const particles=[];
+      const count=40;
+      for(let i=0;i<count;i++){
+        const s=document.createElement('span');
+        s.className='particle';
+        const size=4+Math.random()*4;
+        s.style.width=s.style.height=size+'px';
+        s.style.left=originX+'px';
+        s.style.top=originY+'px';
+        s.style.setProperty('--color',randomColor());
+        particles.push(s);
+        frag.appendChild(s);
+      }
+      document.body.appendChild(frag);
+      particles.forEach(s=>{
+        const angle=Math.random()*Math.PI*2;
+        const dist=120+Math.random()*180;
+        const dx=Math.cos(angle)*dist;
+        const dy=Math.sin(angle)*dist;
+        const bend=Math.random()*60-30;
+        const path=[
+          {x:0,y:0},
+          {x:dx/2+bend,y:dy/2-(40+Math.random()*40)},
+          {x:dx,y:dy},
+          {x:dx+bend*0.5,y:dy+600}
+        ];
+        gsap.to(s,{motionPath:{path,curviness:1.25},duration:3,ease:'power1.inOut',onComplete:()=>s.remove()});
+        gsap.to(s,{rotation:()=>Math.random()*360,repeat:-1,duration:1,ease:'linear'});
+      });
     }
-  }
 
   function randomColor(){
     const h=Math.floor(Math.random()*360);


### PR DESCRIPTION
## Summary
- Reduce confetti particles from 120 to 40 and batch DOM insertion with a document fragment
- Add translate3d to particle style to leverage GPU acceleration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4217fb024832b841bd333516806f6