### PR TITLE
Fix space section rendering

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
-  <script type="module" src="components/vendor/model-viewer.min.js"></script>
+  <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
   <link rel="stylesheet" href="components/common.css"/>
   </head>
 <body class="text-slate-800 selection:bg-[#ffd166]/60">


### PR DESCRIPTION
## Summary
- Load model-viewer from CDN instead of local file to restore the space section

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b6655fd4832b9bb2e8e2e957c9ce