### PR TITLE
Fix space section rendering issues

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -150,6 +150,7 @@ body.space-mode .nav-btn:hover,body.space-mode .nav-btn:focus,body.space-mode .m
 body.space-mode .mob{background:rgba(0,0,0,.8);border-color:rgba(255,255,255,.2)}
 body.space-mode .footer a.link{color:#93c5fd}
 
+#space{background:#000;color:#fff}
 #space .planet{position:relative;border-radius:50%;overflow:hidden}
 #space .planet::before{content:none}
 #space .planet model-viewer{width:100%;height:100%;background:transparent}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -76,7 +76,6 @@
   </div>
   </header>
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>
-</div>  </div>
 </div>
   <div id="msgModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-[100] p-4">
     <div class="msg-box text-[#0f172a] p-6 rounded-xl shadow relative w-full max-w-lg h-96 overflow-y-auto">


### PR DESCRIPTION
## Summary
- Remove stray closing tags after ticker to restore layout
- Add default styling for space section so its content is visible on dark background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bbc98894832b82a928d3e1e12340