### PR TITLE
fix: show sections when IntersectionObserver unsupported

### DIFF
--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -398,8 +398,12 @@ function initCommon(){
   });
   gsap.from('#masthead',{y:-60,opacity:0,duration:.6});
   const revealItems=document.querySelectorAll('.section,.card');
-  const io2=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){gsap.to(e.target,{opacity:1,y:0,duration:.6});io2.unobserve(e.target);}})},{threshold:.2});
-  revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});
+  if('IntersectionObserver' in window){
+    const io2=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){gsap.to(e.target,{opacity:1,y:0,duration:.6});io2.unobserve(e.target);}})},{threshold:.2});
+    revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});
+  }else{
+    revealItems.forEach(el=>{gsap.set(el,{opacity:1,y:0});});
+  }
 
   const gr=document.getElementById('galleryRow');
   if(gr){


### PR DESCRIPTION
## Summary
- ensure sections and cards remain visible on browsers without IntersectionObserver

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4eadeabfc832bb20a89ea2a90447c