### PR TITLE
Ensure space section is visible across devices

### DIFF
--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -399,7 +399,14 @@ function initCommon(){
   gsap.from('#masthead',{y:-60,opacity:0,duration:.6});
   const revealItems=document.querySelectorAll('.section,.card');
   if('IntersectionObserver' in window){
-    const io2=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){gsap.to(e.target,{opacity:1,y:0,duration:.6});io2.unobserve(e.target);}})},{threshold:.2});
+    const io2=new IntersectionObserver(entries=>{
+      entries.forEach(e=>{
+        if(e.isIntersecting){
+          gsap.to(e.target,{opacity:1,y:0,duration:.6});
+          io2.unobserve(e.target);
+        }
+      });
+    },{threshold:.01});
     revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});
   }else{
     revealItems.forEach(el=>{gsap.set(el,{opacity:1,y:0});});
@@ -523,7 +530,7 @@ function initCommon(){
           document.body.classList.remove('space-mode');
         }
       });
-    },{threshold:0.1});
+    },{threshold:0.01});
     spaceIO.observe(spaceSection);
   }
 }


### PR DESCRIPTION
## Summary
- Reduce reveal animation threshold so tall sections like the Space segment become visible immediately.
- Lower space-section observer trigger threshold for consistent dark theme activation.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4edfbbe80832ba0fa48d9e9beab36