### PR TITLE
Add Solar System page and Fun Zone navigation

### DIFF
--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -17,6 +17,21 @@ function initCommon(){
     window.addEventListener('load',updateMast);
   }
   const mobileNav=document.getElementById('mobileNav');
+  const mainNav=document.querySelector('nav.nav');
+  if(mainNav){
+    const funMega=document.createElement('div');
+    funMega.className='mega';
+    funMega.innerHTML=`<button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-earth-americas"></i>Fun Zone</button><div class="panel"><div class="col"><a href="${root}index.html#overview">Overview</a><a href="${root}pages/solar-system.html">Solar System</a></div></div>`;
+    const applyLink=mainNav.querySelector('a.nav-btn[href^="https://vortibd.com"]');
+    mainNav.insertBefore(funMega, applyLink);
+  }
+  if(mobileNav){
+    const funItem=document.createElement('div');
+    funItem.className='mitem';
+    funItem.innerHTML=`<button class="mhead"><i class="fa-solid fa-earth-americas"></i><span>Fun Zone</span></button><div class="msub"><a class="mlink" href="${root}index.html#overview">Overview</a><a class="mlink" href="${root}pages/solar-system.html">Solar System</a></div>`;
+    const applyMobile=mobileNav.querySelector('a.mlink[href^="https://vortibd.com"]');
+    mobileNav.insertBefore(funItem, applyMobile);
+  }
   const handleResize=()=>{
     if(window.innerWidth>=768 && mobileNav && !mobileNav.classList.contains('hidden')) mobileNav.classList.add('hidden');
     updateMast();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -286,97 +286,12 @@
 
   <section id="admission" class="section"><div class="wrap"><div class="head"><h2>Admission</h2><span class="muted">Clear steps • Online apply</span></div><div class="cta-row"><a class="cta green" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">Apply Online</a></div></div></section>
 
-  <section id="space" class="section">
-    <div class="wrap">
-      <div class="head"><h2>Let's Visit the Space</h2></div>
-        <div class="space-items space-y-16">
-          <div class="item flex flex-col md:flex-row items-center gap-8">
-            <div class="flex flex-col items-center text-center">
-              <div class="planet sun"><model-viewer src="assets/planets/sun/sun.gltf" alt="Sun" auto-rotate camera-controls disable-zoom></model-viewer></div>
-              <h3 class="text-2xl font-bold mt-2">Sun</h3>
-            </div>
-            <p class="max-w-md text-justify">
-              The Sun is a nearly perfect sphere of hot plasma at the heart of the solar system. Its core reaches temperatures of about 15 million degrees Celsius where nuclear fusion occurs. By fusing hydrogen into helium, the Sun releases vast amounts of energy that radiate outward. This energy travels through the Sun's layers before reaching its surface, the photosphere. Sunspots and solar flares on the photosphere reveal the Sun’s complex magnetic activity. Solar winds, streams of charged particles, flow from the Sun into space and interact with planetary atmospheres. The Sun accounts for more than 99 percent of the solar system’s mass. Earth orbits the Sun at an average distance of 150 million kilometers, receiving light in about eight minutes. Scientists study the Sun to better understand stellar lifecycles and space weather. Over billions of years, the Sun will evolve into a red giant before ending as a white dwarf. Its stable energy output has allowed life to develop and thrive on Earth.
-            </p>
-          </div>
-          <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
-            <div class="flex flex-col items-center text-center">
-              <div class="planet mercury"><model-viewer src="assets/planets/mercury/mercury.gltf" alt="Mercury" auto-rotate camera-controls disable-zoom></model-viewer></div>
-              <h3 class="text-2xl font-bold mt-2">Mercury</h3>
-            </div>
-            <p class="max-w-md text-justify">
-              Mercury is the innermost planet, orbiting the Sun faster than any other world. A year on Mercury lasts only 88 Earth days because of its proximity to the Sun. Its surface resembles the Moon, marked by craters from countless meteor impacts. With almost no atmosphere, Mercury cannot retain heat or block incoming meteoroids. Daytime temperatures soar above 400°C while nights plummet below -170°C. Mercury’s large iron core makes up about 60 percent of its mass. The planet has a weak magnetic field, hinting at a partially molten core. Spacecraft like Mariner 10 and MESSENGER have mapped most of Mercury's surface. The planet experiences long days; one rotation takes 59 Earth days. Mercury's sky remains black even during the day due to the thin exosphere. Despite harsh conditions, studying Mercury helps scientists learn about planet formation near stars.
-            </p>
-          </div>
-          <div class="item flex flex-col md:flex-row items-center gap-8">
-            <div class="flex flex-col items-center text-center">
-              <div class="planet venus"><model-viewer src="assets/planets/venus/venus.gltf" alt="Venus" auto-rotate camera-controls disable-zoom></model-viewer></div>
-              <h3 class="text-2xl font-bold mt-2">Venus</h3>
-            </div>
-            <p class="max-w-md text-justify">
-              Venus is the second planet from the Sun, often called Earth's twin due to its similar size. Its surface temperature averages around 465°C, hot enough to melt lead. A dense atmosphere of carbon dioxide creates a runaway greenhouse effect. Thick clouds of sulfuric acid reflect sunlight, making Venus the brightest planet in the night sky. A day on Venus is longer than its year; it rotates once every 243 Earth days. The planet spins retrograde, rotating opposite its orbit around the Sun. Radar mapping reveals vast plains, highland regions, and thousands of volcanoes. Venus lacks a global magnetic field, leaving its atmosphere exposed to solar winds. Probes like Magellan and Venus Express have studied its surface and atmosphere. Future missions aim to uncover how Venus evolved so differently from Earth. Understanding Venus helps scientists learn about greenhouse effects on other worlds.
-            </p>
-          </div>
-          <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
-            <div class="flex flex-col items-center text-center">
-              <div class="planet earth"><model-viewer src="assets/planets/earth/earth.gltf" alt="Earth" auto-rotate camera-controls disable-zoom></model-viewer></div>
-              <h3 class="text-2xl font-bold mt-2">Earth</h3>
-            </div>
-            <p class="max-w-md text-justify">
-              Earth is the third planet from the Sun and the only known world to harbor life. About 71 percent of Earth's surface is covered by water, forming oceans, seas, and lakes. The atmosphere contains nitrogen, oxygen, and trace gases that regulate temperature and support life. Earth's magnetic field shields the planet from solar winds and cosmic radiation. Plate tectonics continually reshape the surface through earthquakes and volcanic activity. The planet has one natural satellite, the Moon, which influences tides and stabilizes Earth's tilt. Earth completes a rotation every 24 hours, creating the cycle of day and night. A year on Earth lasts 365.25 days, leading to the leap year every four years. Diverse ecosystems from rainforests to deserts support millions of species. Human civilization has developed complex cultures, technologies, and societies on Earth. Ongoing climate change poses challenges that require global cooperation to address.
-            </p>
-          </div>
-          <div class="item flex flex-col md:flex-row items-center gap-8">
-            <div class="flex flex-col items-center text-center">
-              <div class="planet mars"><model-viewer src="assets/planets/mars/mars.gltf" alt="Mars" auto-rotate camera-controls disable-zoom></model-viewer></div>
-              <h3 class="text-2xl font-bold mt-2">Mars</h3>
-            </div>
-            <p class="max-w-md text-justify">
-              Mars is the fourth planet from the Sun and known as the Red Planet. Its reddish color comes from iron oxide dust covering its surface. Mars has a thin atmosphere mostly composed of carbon dioxide. The planet features the largest volcano in the solar system, Olympus Mons. Valles Marineris, a canyon system, stretches over 4,000 kilometers across Mars. Polar ice caps made of water and dry ice grow and shrink with the seasons. Mars has two small moons, Phobos and Deimos, likely captured asteroids. Dust storms can engulf the entire planet and last for months. Robotic missions like Perseverance and Curiosity explore its surface for signs of past life. Evidence suggests liquid water once flowed on Mars billions of years ago. Studying Mars prepares humanity for potential future crewed missions to the planet.
-            </p>
-          </div>
-          <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
-            <div class="flex flex-col items-center text-center">
-              <div class="planet jupiter"><model-viewer src="assets/planets/jupiter/jupiter.gltf" alt="Jupiter" auto-rotate camera-controls disable-zoom></model-viewer></div>
-              <h3 class="text-2xl font-bold mt-2">Jupiter</h3>
-            </div>
-            <p class="max-w-md text-justify">
-              Jupiter is the largest planet in the solar system, more massive than all others combined. It is a gas giant composed mostly of hydrogen and helium with no solid surface. The planet's atmosphere features bands of clouds driven by fast winds up to 400 mph. The Great Red Spot, a storm larger than Earth, has raged for centuries. Jupiter emits more heat than it receives from the Sun due to internal contraction. Its strong magnetic field creates intense radiation belts and dazzling auroras. Jupiter has at least 79 moons, including Ganymede, the largest in the solar system. The Galilean moons—Io, Europa, Ganymede, and Callisto—were first observed by Galileo in 1610. The planet's powerful gravity influences the orbits of comets and asteroids. NASA's Juno mission has provided detailed information about Jupiter's atmosphere and core. Studying Jupiter helps scientists understand how giant planets form and evolve.
-            </p>
-          </div>
-          <div class="item flex flex-col md:flex-row items-center gap-8">
-            <div class="flex flex-col items-center text-center">
-              <div class="planet saturn">
-                <model-viewer src="assets/planets/saturn/saturn_with_rings.gltf" alt="Saturn" auto-rotate camera-controls disable-zoom></model-viewer>
-              </div>
-              <h3 class="text-2xl font-bold mt-2">Saturn</h3>
-            </div>
-            <p class="max-w-md text-justify">
-              Saturn is famous for its majestic ring system made of ice, rock, and dust particles. The planet is a gas giant primarily composed of hydrogen and helium. Despite its size, Saturn is less dense than water and could float in a vast ocean. Winds in Saturn's atmosphere can reach speeds of over 1,000 mph. The hexagon-shaped storm at the north pole is a unique atmospheric phenomenon. Saturn's rings are divided into several sections named alphabetically in order of discovery. The planet has more than 80 moons, with Titan being larger than the planet Mercury. Titan’s thick atmosphere and liquid methane lakes intrigue astrobiologists. The Cassini-Huygens mission orbited Saturn for 13 years, revealing stunning details. Saturn takes about 29.5 Earth years to complete one orbit around the Sun. The planet's rapid rotation, about 10.7 hours, causes it to bulge at the equator.
-            </p>
-          </div>
-          <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
-            <div class="flex flex-col items-center text-center">
-              <div class="planet uranus"><model-viewer src="assets/planets/uranus/uranus.gltf" alt="Uranus" auto-rotate camera-controls disable-zoom></model-viewer></div>
-              <h3 class="text-2xl font-bold mt-2">Uranus</h3>
-            </div>
-            <p class="max-w-md text-justify">
-              Uranus is an ice giant with a pale blue color due to methane in its atmosphere. It rotates on its side with an axial tilt of 98 degrees, making it appear to roll along its orbit. Each pole experiences decades of continuous sunlight or darkness during its 84-year orbit. The atmosphere consists mainly of hydrogen, helium, and traces of icy methane. Uranus has faint rings composed of dark particles and dust. Winds on Uranus can reach speeds of 560 mph despite its cold temperatures. The planet has at least 27 known moons named after characters from Shakespeare and Alexander Pope. Its magnetic field is tilted and offset from the planet's center, creating unusual magnetospheres. Voyager 2 is the only spacecraft to have visited Uranus, flying by in 1986. The planet's internal heat is surprisingly low compared to other giant planets. Understanding Uranus helps scientists explore the diversity of planetary systems.
-            </p>
-          </div>
-          <div class="item flex flex-col md:flex-row items-center gap-8">
-            <div class="flex flex-col items-center text-center">
-              <div class="planet neptune"><model-viewer src="assets/planets/neptune/neptune.gltf" alt="Neptune" auto-rotate camera-controls disable-zoom></model-viewer></div>
-              <h3 class="text-2xl font-bold mt-2">Neptune</h3>
-            </div>
-            <p class="max-w-md text-justify">
-              Neptune is the outermost known planet, completing an orbit around the Sun every 165 Earth years. It is an ice giant with a deep blue color due to methane in its atmosphere. The planet's winds are the fastest in the solar system, reaching speeds over 1,200 mph. Large storms like the Great Dark Spot appear and disappear in its atmosphere. Neptune emits more internal heat than it receives from the Sun. The planet has a faint ring system composed of dust and rock. Triton, Neptune's largest moon, orbits in a retrograde direction and may host a subsurface ocean. Voyager 2 provided the only close-up images of Neptune during its 1989 flyby. The planet's magnetic field is tilted and offset, creating complex auroras. Neptune's gravity influences the Kuiper Belt, a region of icy bodies beyond its orbit. Studying Neptune offers insight into the outer edges of planetary systems.
-            </p>
-          </div>
-        </div>
-      </div>
-    </section>
-
+  <section id="explore-more" class="section">
+    <div class="wrap text-center">
+      <h2 class="text-3xl font-bold mb-4">Want to explore more?</h2>
+      <a class="cta green" href="pages/solar-system.html">Explore the Solar System</a>
+    </div>
+  </section>
 <footer class="footer">
   <div class="wrap">
     <div class="grid gap-6 md:grid-cols-2 text-center md:text-left">

--- a/frontend/pages/solar-system.html
+++ b/frontend/pages/solar-system.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="bn">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Solar System - Ispahani Public School & College</title>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+Bengali:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/MotionPathPlugin.min.js" defer></script>
+  <script type="module" src="../components/vendor/model-viewer.min.js"></script>
+  <link rel="stylesheet" href="../components/common.css"/>
+</head>
+<body class="text-slate-800 selection:bg-[#ffd166]/60">
+  <div id="decor"></div>
+<div id="masthead">
+  <div class="topbar"><div class="wrap"><span>EIIN 105826</span><span>College 7925</span><span>School 7801</span></div></div>
+  <header class="header">
+  <div class="wrap">
+    <a href="../index.html" class="brand">
+      <img id="logoImg" loading="eager" src="../assets/ipsc-logo.png" alt="Logo">
+      <div class="btext"><strong>Ispahani Public School & College</strong><span>Comilla Cantonment</span></div>
+    </a>
+    <div class="controls">
+      <nav class="nav" aria-label="Primary">
+        <a class="nav-btn" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-graduation-cap"></i>Academics</button><div class="panel two"><div class="col"><h4>Programs</h4><a href="../index.html#houses">Houses</a><a href="../index.html#classes">Classes</a></div><div class="col"><h4>Resources</h4><a href="../index.html#resources">Syllabus (PDF)</a><a href="../index.html#resources">Question Bank</a><a href="../index.html#resources">e-Library</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-school"></i>Campus</button><div class="panel two"><div class="col"><h4>Facilities</h4><a href="../index.html#facilities">Labs & Library</a><a href="../index.html#facilities">Playgrounds</a></div><div class="col"><h4>Activities</h4><a href="clubs.html">Clubs & Societies</a><a href="../index.html#gallery">Gallery</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-screwdriver-wrench"></i>Facilities</button><div class="panel"><div class="col"><a href="facilities.html">Overview</a><a href="transport.html">Transport</a><a href="staff-quarter.html">Staff Quarter</a></div></div></div>
+        <div class="mega"><button class="nav-btn" aria-haspopup="true"><i class="fa-solid fa-users-gear"></i>Administration</button><div class="panel"><div class="col"><a href="governing.html">Governing Body</a><a href="teachers.html">Teachers</a><a href="staffs.html">Staffs</a></div></div></div>
+        <a class="nav-btn" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+        <a class="nav-btn login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
+      </nav>
+      <a href="../index.html" class="nav-btn icon mobile-home" aria-label="Home"><i class="fa-solid fa-house"></i></a>
+      <button id="mobileToggle" class="hamb" aria-label="Open menu">☰</button>
+    </div>
+  </div>
+  <div id="mobileNav" class="mob hidden">
+    <a class="mlink" href="../index.html"><i class="fa-solid fa-house"></i>Home</a>
+    <div class="mitem">
+      <button class="mhead"><i class="fa-solid fa-graduation-cap"></i><span>Academics</span></button>
+      <div class="msub">
+        <a class="mlink" href="../index.html#houses">Houses</a>
+        <a class="mlink" href="../index.html#classes">Classes</a>
+        <a class="mlink" href="../index.html#resources">Syllabus (PDF)</a>
+        <a class="mlink" href="../index.html#resources">Question Bank</a>
+        <a class="mlink" href="../index.html#resources">e-Library</a>
+      </div>
+    </div>
+    <div class="mitem">
+      <button class="mhead"><i class="fa-solid fa-school"></i><span>Campus</span></button>
+      <div class="msub">
+        <a class="mlink" href="../index.html#facilities">Labs &amp; Library</a>
+        <a class="mlink" href="../index.html#facilities">Playgrounds</a>
+        <a class="mlink" href="clubs.html">Clubs &amp; Societies</a>
+        <a class="mlink" href="../index.html#gallery">Gallery</a>
+      </div>
+    </div>
+    <div class="mitem">
+      <button class="mhead"><i class="fa-solid fa-screwdriver-wrench"></i><span>Facilities</span></button>
+      <div class="msub">
+        <a class="mlink" href="facilities.html">Overview</a>
+        <a class="mlink" href="transport.html">Transport</a>
+        <a class="mlink" href="staff-quarter.html">Staff Quarter</a>
+      </div>
+    </div>
+    <div class="mitem">
+      <button class="mhead"><i class="fa-solid fa-users-gear"></i><span>Administration</span></button>
+      <div class="msub">
+        <a class="mlink" href="governing.html">Governing Body</a>
+        <a class="mlink" href="teachers.html">Teachers</a>
+        <a class="mlink" href="staffs.html">Staffs</a>
+      </div>
+    </div>
+    <a class="mlink" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener"><i class="fa-solid fa-file-pen"></i>Apply</a>
+    <a class="mlink login" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener"><i class="fa-solid fa-right-to-bracket"></i>Login</a>
+  </div>
+  </header>
+  <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="../index.html#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="../index.html#" class="tick">HSC Model Test Routine — Download PDF</a><a href="../index.html#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="../index.html#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>
+</div>  </div>
+</div>
+<div id="msgModal" class="fixed inset-0 bg-black/60 flex items-center justify-center z-[100] p-4">
+  <div class="msg-box text-[#0f172a] p-6 rounded-xl shadow relative w-full max-w-lg h-96 overflow-y-auto">
+    <button id="msgClose" class="absolute top-2 right-2 text-2xl leading-none" aria-label="Close">×</button>
+    <h3 id="msgTitle" class="font-bold text-center mb-4"></h3>
+    <div id="msgText" class="whitespace-pre-line"></div>
+  </div>
+</div>
+
+  <section id="space" class="section">
+    <div class="wrap">
+      <div class="head"><h2>Let's Visit the Space</h2></div>
+        <div class="space-items space-y-16">
+          <div class="item flex flex-col md:flex-row items-center gap-8">
+            <div class="flex flex-col items-center text-center">
+              <div class="planet sun"><model-viewer src="../assets/planets/sun/sun.gltf" alt="Sun" auto-rotate camera-controls disable-zoom></model-viewer></div>
+              <h3 class="text-2xl font-bold mt-2">Sun</h3>
+            </div>
+            <p class="max-w-md text-justify">
+              The Sun is a nearly perfect sphere of hot plasma at the heart of the solar system. Its core reaches temperatures of about 15 million degrees Celsius where nuclear fusion occurs. By fusing hydrogen into helium, the Sun releases vast amounts of energy that radiate outward. This energy travels through the Sun's layers before reaching its surface, the photosphere. Sunspots and solar flares on the photosphere reveal the Sun’s complex magnetic activity. Solar winds, streams of charged particles, flow from the Sun into space and interact with planetary atmospheres. The Sun accounts for more than 99 percent of the solar system’s mass. Earth orbits the Sun at an average distance of 150 million kilometers, receiving light in about eight minutes. Scientists study the Sun to better understand stellar lifecycles and space weather. Over billions of years, the Sun will evolve into a red giant before ending as a white dwarf. Its stable energy output has allowed life to develop and thrive on Earth.
+            </p>
+          </div>
+          <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
+            <div class="flex flex-col items-center text-center">
+              <div class="planet mercury"><model-viewer src="../assets/planets/mercury/mercury.gltf" alt="Mercury" auto-rotate camera-controls disable-zoom></model-viewer></div>
+              <h3 class="text-2xl font-bold mt-2">Mercury</h3>
+            </div>
+            <p class="max-w-md text-justify">
+              Mercury is the innermost planet, orbiting the Sun faster than any other world. A year on Mercury lasts only 88 Earth days because of its proximity to the Sun. Its surface resembles the Moon, marked by craters from countless meteor impacts. With almost no atmosphere, Mercury cannot retain heat or block incoming meteoroids. Daytime temperatures soar above 400°C while nights plummet below -170°C. Mercury’s large iron core makes up about 60 percent of its mass. The planet has a weak magnetic field, hinting at a partially molten core. Spacecraft like Mariner 10 and MESSENGER have mapped most of Mercury's surface. The planet experiences long days; one rotation takes 59 Earth days. Mercury's sky remains black even during the day due to the thin exosphere. Despite harsh conditions, studying Mercury helps scientists learn about planet formation near stars.
+            </p>
+          </div>
+          <div class="item flex flex-col md:flex-row items-center gap-8">
+            <div class="flex flex-col items-center text-center">
+              <div class="planet venus"><model-viewer src="../assets/planets/venus/venus.gltf" alt="Venus" auto-rotate camera-controls disable-zoom></model-viewer></div>
+              <h3 class="text-2xl font-bold mt-2">Venus</h3>
+            </div>
+            <p class="max-w-md text-justify">
+              Venus is the second planet from the Sun, often called Earth's twin due to its similar size. Its surface temperature averages around 465°C, hot enough to melt lead. A dense atmosphere of carbon dioxide creates a runaway greenhouse effect. Thick clouds of sulfuric acid reflect sunlight, making Venus the brightest planet in the night sky. A day on Venus is longer than its year; it rotates once every 243 Earth days. The planet spins retrograde, rotating opposite its orbit around the Sun. Radar mapping reveals vast plains, highland regions, and thousands of volcanoes. Venus lacks a global magnetic field, leaving its atmosphere exposed to solar winds. Probes like Magellan and Venus Express have studied its surface and atmosphere. Future missions aim to uncover how Venus evolved so differently from Earth. Understanding Venus helps scientists learn about greenhouse effects on other worlds.
+            </p>
+          </div>
+          <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
+            <div class="flex flex-col items-center text-center">
+              <div class="planet earth"><model-viewer src="../assets/planets/earth/earth.gltf" alt="Earth" auto-rotate camera-controls disable-zoom></model-viewer></div>
+              <h3 class="text-2xl font-bold mt-2">Earth</h3>
+            </div>
+            <p class="max-w-md text-justify">
+              Earth is the third planet from the Sun and the only known world to harbor life. About 71 percent of Earth's surface is covered by water, forming oceans, seas, and lakes. The atmosphere contains nitrogen, oxygen, and trace gases that regulate temperature and support life. Earth's magnetic field shields the planet from solar winds and cosmic radiation. Plate tectonics continually reshape the surface through earthquakes and volcanic activity. The planet has one natural satellite, the Moon, which influences tides and stabilizes Earth's tilt. Earth completes a rotation every 24 hours, creating the cycle of day and night. A year on Earth lasts 365.25 days, leading to the leap year every four years. Diverse ecosystems from rainforests to deserts support millions of species. Human civilization has developed complex cultures, technologies, and societies on Earth. Ongoing climate change poses challenges that require global cooperation to address.
+            </p>
+          </div>
+          <div class="item flex flex-col md:flex-row items-center gap-8">
+            <div class="flex flex-col items-center text-center">
+              <div class="planet mars"><model-viewer src="../assets/planets/mars/mars.gltf" alt="Mars" auto-rotate camera-controls disable-zoom></model-viewer></div>
+              <h3 class="text-2xl font-bold mt-2">Mars</h3>
+            </div>
+            <p class="max-w-md text-justify">
+              Mars is the fourth planet from the Sun and known as the Red Planet. Its reddish color comes from iron oxide dust covering its surface. Mars has a thin atmosphere mostly composed of carbon dioxide. The planet features the largest volcano in the solar system, Olympus Mons. Valles Marineris, a canyon system, stretches over 4,000 kilometers across Mars. Polar ice caps made of water and dry ice grow and shrink with the seasons. Mars has two small moons, Phobos and Deimos, likely captured asteroids. Dust storms can engulf the entire planet and last for months. Robotic missions like Perseverance and Curiosity explore its surface for signs of past life. Evidence suggests liquid water once flowed on Mars billions of years ago. Studying Mars prepares humanity for potential future crewed missions to the planet.
+            </p>
+          </div>
+          <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
+            <div class="flex flex-col items-center text-center">
+              <div class="planet jupiter"><model-viewer src="../assets/planets/jupiter/jupiter.gltf" alt="Jupiter" auto-rotate camera-controls disable-zoom></model-viewer></div>
+              <h3 class="text-2xl font-bold mt-2">Jupiter</h3>
+            </div>
+            <p class="max-w-md text-justify">
+              Jupiter is the largest planet in the solar system, more massive than all others combined. It is a gas giant composed mostly of hydrogen and helium with no solid surface. The planet's atmosphere features bands of clouds driven by fast winds up to 400 mph. The Great Red Spot, a storm larger than Earth, has raged for centuries. Jupiter emits more heat than it receives from the Sun due to internal contraction. Its strong magnetic field creates intense radiation belts and dazzling auroras. Jupiter has at least 79 moons, including Ganymede, the largest in the solar system. The Galilean moons—Io, Europa, Ganymede, and Callisto—were first observed by Galileo in 1610. The planet's powerful gravity influences the orbits of comets and asteroids. NASA's Juno mission has provided detailed information about Jupiter's atmosphere and core. Studying Jupiter helps scientists understand how giant planets form and evolve.
+            </p>
+          </div>
+          <div class="item flex flex-col md:flex-row items-center gap-8">
+            <div class="flex flex-col items-center text-center">
+              <div class="planet saturn">
+                <model-viewer src="../assets/planets/saturn/saturn_with_rings.gltf" alt="Saturn" auto-rotate camera-controls disable-zoom></model-viewer>
+              </div>
+              <h3 class="text-2xl font-bold mt-2">Saturn</h3>
+            </div>
+            <p class="max-w-md text-justify">
+              Saturn is famous for its majestic ring system made of ice, rock, and dust particles. The planet is a gas giant primarily composed of hydrogen and helium. Despite its size, Saturn is less dense than water and could float in a vast ocean. Winds in Saturn's atmosphere can reach speeds of over 1,000 mph. The hexagon-shaped storm at the north pole is a unique atmospheric phenomenon. Saturn's rings are divided into several sections named alphabetically in order of discovery. The planet has more than 80 moons, with Titan being larger than the planet Mercury. Titan’s thick atmosphere and liquid methane lakes intrigue astrobiologists. The Cassini-Huygens mission orbited Saturn for 13 years, revealing stunning details. Saturn takes about 29.5 Earth years to complete one orbit around the Sun. The planet's rapid rotation, about 10.7 hours, causes it to bulge at the equator.
+            </p>
+          </div>
+          <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
+            <div class="flex flex-col items-center text-center">
+              <div class="planet uranus"><model-viewer src="../assets/planets/uranus/uranus.gltf" alt="Uranus" auto-rotate camera-controls disable-zoom></model-viewer></div>
+              <h3 class="text-2xl font-bold mt-2">Uranus</h3>
+            </div>
+            <p class="max-w-md text-justify">
+              Uranus is an ice giant with a pale blue color due to methane in its atmosphere. It rotates on its side with an axial tilt of 98 degrees, making it appear to roll along its orbit. Each pole experiences decades of continuous sunlight or darkness during its 84-year orbit. The atmosphere consists mainly of hydrogen, helium, and traces of icy methane. Uranus has faint rings composed of dark particles and dust. Winds on Uranus can reach speeds of 560 mph despite its cold temperatures. The planet has at least 27 known moons named after characters from Shakespeare and Alexander Pope. Its magnetic field is tilted and offset from the planet's center, creating unusual magnetospheres. Voyager 2 is the only spacecraft to have visited Uranus, flying by in 1986. The planet's internal heat is surprisingly low compared to other giant planets. Understanding Uranus helps scientists explore the diversity of planetary systems.
+            </p>
+          </div>
+          <div class="item flex flex-col md:flex-row items-center gap-8">
+            <div class="flex flex-col items-center text-center">
+              <div class="planet neptune"><model-viewer src="../assets/planets/neptune/neptune.gltf" alt="Neptune" auto-rotate camera-controls disable-zoom></model-viewer></div>
+              <h3 class="text-2xl font-bold mt-2">Neptune</h3>
+            </div>
+            <p class="max-w-md text-justify">
+              Neptune is the outermost known planet, completing an orbit around the Sun every 165 Earth years. It is an ice giant with a deep blue color due to methane in its atmosphere. The planet's winds are the fastest in the solar system, reaching speeds over 1,200 mph. Large storms like the Great Dark Spot appear and disappear in its atmosphere. Neptune emits more internal heat than it receives from the Sun. The planet has a faint ring system composed of dust and rock. Triton, Neptune's largest moon, orbits in a retrograde direction and may host a subsurface ocean. Voyager 2 provided the only close-up images of Neptune during its 1989 flyby. The planet's magnetic field is tilted and offset, creating complex auroras. Neptune's gravity influences the Kuiper Belt, a region of icy bodies beyond its orbit. Studying Neptune offers insight into the outer edges of planetary systems.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+<footer class="footer">
+  <div class="wrap">
+    <div class="grid gap-6 md:grid-cols-2 text-center md:text-left">
+      <div class="contact">
+        <h4 class="font-bold mb-2">Contact</h4>
+        <p>Cumilla Cantonment 3501, Cumilla</p>
+        <p>Phone: 03239933170</p>
+        <p>Mobile: 01733063001</p>
+        <p>Email: ipscm1@gmail.com</p>
+      </div>
+      <div class="links">
+        <h4 class="font-bold mb-2">গুরুত্বপূর্ণ লিঙ্ক</h4>
+        <ul class="space-y-1">
+          <li><a class="link" href="https://comillaboard.portal.gov.bd/" target="_blank" rel="noopener">Comilla Education Board</a></li>
+          <li><a class="link" href="https://shed.gov.bd/" target="_blank" rel="noopener">মাধ্যমিক ও উচ্চ শিক্ষা বিভাগ</a></li>
+          <li><a class="link" href="https://bangladesh.gov.bd/index.php" target="_blank" rel="noopener">বাংলাদেশ জাতীয় শিক্ষা বাতায়ন</a></li>
+          <li><a class="link" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">CloudCampus Portal</a></li>
+          <li><a class="link" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">VortiBD Apply</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="mt-6 pt-4 border-t flex flex-col md:flex-row justify-between items-center text-sm">
+      <span>© <span data-year></span> Mahfuz Alam Shohan</span>
+      <span>© <span data-year></span> Ispahani Public School & College</span>
+    </div>
+  </div>
+  </footer>
+    <script src="components/student-galleries.js" defer></script>
+    <script src="components/teachers.js" defer></script>
+    <script src="components/common.js" defer></script>
+  </body>
+  </html>
+
+
+<footer class="footer">
+  <div class="wrap">
+    <div class="grid gap-6 md:grid-cols-2 text-center md:text-left">
+      <div class="contact">
+        <h4 class="font-bold mb-2">Contact</h4>
+        <p>Cumilla Cantonment 3501, Cumilla</p>
+        <p>Phone: 03239933170</p>
+        <p>Mobile: 01733063001</p>
+        <p>Email: ipscm1@gmail.com</p>
+      </div>
+      <div class="links">
+        <h4 class="font-bold mb-2">গুরুত্বপূর্ণ লিঙ্ক</h4>
+        <ul class="space-y-1">
+          <li><a class="link" href="https://comillaboard.portal.gov.bd/" target="_blank" rel="noopener">Comilla Education Board</a></li>
+          <li><a class="link" href="https://shed.gov.bd/" target="_blank" rel="noopener">মাধ্যমিক ও উচ্চ শিক্ষা বিভাগ</a></li>
+          <li><a class="link" href="https://bangladesh.gov.bd/index.php" target="_blank" rel="noopener">বাংলাদেশ জাতীয় শিক্ষা বাতায়ন</a></li>
+          <li><a class="link" href="https://portal.cloudcampus24.com/UserAuth/Login?ReturnUrl=%2F" target="_blank" rel="noopener">CloudCampus Portal</a></li>
+          <li><a class="link" href="https://vortibd.com/institute/39/96" target="_blank" rel="noopener">VortiBD Apply</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="mt-6 pt-4 border-t flex flex-col md:flex-row justify-between items-center text-sm">
+      <span>© <span data-year></span> Mahfuz Alam Shohan</span>
+      <span>© <span data-year></span> Ispahani Public School & College</span>
+    </div>
+  </div>
+</footer>
+<script src="../components/common.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace homepage space section with a call-to-action linking to a dedicated Solar System page.
- Add dynamic "Fun Zone" navigation links for Overview and Solar System across all pages.
- Introduce a new Solar System page showcasing planetary details.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c50446bad4832b86a72785b958b001