### PR TITLE
Make space section transparent to reveal star field

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -150,7 +150,7 @@ body.space-mode .nav-btn:hover,body.space-mode .nav-btn:focus,body.space-mode .m
 body.space-mode .mob{background:rgba(0,0,0,.8);border-color:rgba(255,255,255,.2)}
 body.space-mode .footer a.link{color:#93c5fd}
 
-#space{background:#000;color:#fff}
+#space{background:transparent;color:#fff}
 #space .planet{position:relative;border-radius:50%;overflow:hidden}
 #space .planet::before{content:none}
 #space .planet model-viewer{width:100%;height:100%;background:transparent}
@@ -165,4 +165,4 @@ body.space-mode .footer a.link{color:#93c5fd}
 #space .neptune{width:160px;height:160px}
 #space .item{margin:3rem 0}
 
-#space .item p{flex:1;max-width:60ch}
+#space .item p{flex:1;max-width:60ch;background:transparent}


### PR DESCRIPTION
## Summary
- Remove black background from space section so star field remains visible.
- Ensure paragraphs within space section have transparent backgrounds.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c50c257800832bb2ec540fd8c279a4