### PR TITLE
feat: enlarge Saturn and refine ring material

### DIFF
--- a/frontend/assets/planets/saturn/saturn_with_rings.gltf
+++ b/frontend/assets/planets/saturn/saturn_with_rings.gltf
@@ -196,8 +196,8 @@
           1.0,
           1.0
         ],
-        "metallicFactor": 0,
-        "roughnessFactor": 1,
+        "metallicFactor": 0.1,
+        "roughnessFactor": 0.6,
         "baseColorTexture": {
           "index": 1
         }
@@ -207,7 +207,7 @@
         0.0,
         0.0
       ],
-      "alphaMode": "OPAQUE",
+      "alphaMode": "BLEND",
       "doubleSided": true,
       "name": "SaturnRing"
     }
@@ -245,7 +245,8 @@
   "nodes": [
     {
       "mesh": 0,
-      "name": "Saturn"
+      "name": "Saturn",
+      "scale": [1.5, 1.5, 1.5]
     },
     {
       "mesh": 1,

--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -174,7 +174,7 @@ body.space-mode .footer a.link{color:#93c5fd}
 #space .earth{width:160px;height:160px}
 #space .mars{width:160px;height:160px}
 #space .jupiter{width:160px;height:160px}
-#space .saturn{width:160px;height:160px}
+#space .saturn{width:240px;height:240px}
 #space .uranus{width:160px;height:160px}
 #space .neptune{width:160px;height:160px}
 #space .item{margin:3rem 0}


### PR DESCRIPTION
## Summary
- enlarge Saturn container for better planet-to-ring proportions
- scale Saturn sphere within glTF and apply blended PBR for rings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c51fcb0404832b88ff19d755092324