### PR TITLE
Align solar dropdown with dark theme and preload homepage content

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -149,6 +149,11 @@ body.space-mode .nav-btn,body.space-mode .nav-btn i,body.space-mode .mlink,body.
 body.space-mode .nav-btn:hover,body.space-mode .nav-btn:focus,body.space-mode .mlink:hover{background:rgba(255,255,255,.2)}
 body.space-mode .mob{background:rgba(0,0,0,.8);border-color:rgba(255,255,255,.2)}
 body.space-mode .footer a.link{color:#93c5fd}
+body.space-mode .mega .panel{background:rgba(0,0,0,.8);border-color:rgba(255,255,255,.2)}
+body.space-mode .mega .panel .col h4{color:#e2e8f0}
+body.space-mode .mega .panel .col a{color:#fff}
+body.space-mode .mega .panel .col a:hover{background:rgba(255,255,255,.1)}
+body.space-mode .mob .msub .mlink{border-color:rgba(255,255,255,.2)}
 
 #space{background:transparent;color:#fff}
 #space .planet{position:relative;border-radius:50%;overflow:hidden}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -137,7 +137,7 @@ function initCommon(){
         const img=document.createElement('img');
         img.src=root+'assets/staffs/pictures/'+s.id+'.jpg';
         img.alt=s.name;
-        img.loading='lazy';
+        img.loading='eager';
         img.decoding='async';
         img.className=full?'w-24 h-24 object-cover rounded-lg ring-2 ring-white':'w-24 h-24 object-cover rounded-lg mb-3 ring-2 ring-white';
         img.onerror=()=>{img.remove();};
@@ -243,7 +243,7 @@ function initCommon(){
         const img=document.createElement('img');
         img.src=root+'assets/governing/pictures/'+m.id+'.jpg';
         img.alt=m.name;
-        img.loading='lazy';
+          img.loading='eager';
         img.decoding='async';
         img.className='w-24 h-24 object-cover rounded-full';
         img.onerror=()=>{img.remove();};
@@ -445,7 +445,7 @@ function initCommon(){
     ];
     images.forEach(src=>{
       const img=document.createElement('img');
-      img.loading='lazy';
+      img.loading='eager';
       img.decoding='async';
       img.alt='Gallery image';
       img.src=src;

--- a/frontend/components/teachers.js
+++ b/frontend/components/teachers.js
@@ -57,7 +57,7 @@ function createCard(t,root,full){
   const img=document.createElement('img');
   img.src=root+'assets/teachers/pictures/'+t.id+'.jpg';
   img.alt=t.name;
-  img.loading='lazy';
+  img.loading='eager';
   img.decoding='async';
   img.className='w-32 h-32 object-cover rounded-full mb-3 cursor-pointer ring-4 ring-white';
   img.style.boxShadow='0 0 0 4px #fff,0 0 20px rgba(20,83,45,0.45)';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -111,15 +111,15 @@
     <p class="section-desc">প্রতিষ্ঠানের নেতৃত্ব বৃন্দের বার্তাগুলি শিক্ষার্থীদের অনুপ্রাণিত ও দিকনির্দেশনা প্রদান করে, যা তাদের ভবিষ্যৎ গঠনে সহায়তা করে। প্রধান অভিভাবক, অধ্যক্ষ ও অন্যান্য নেতৃবৃন্দের অভিজ্ঞতা থেকে উঠে আসা পরামর্শ ও মনোবল প্রেরণার কথা এখানে তুলে ধরা হয়।</p>
     <div class="leaders">
       <article class="leader" data-info="assets/leaders/leader-1.txt">
-        <div class="avatar"><img loading="lazy" decoding="async" src="assets/leaders/leader-1.jpg" alt="Chief Patron"></div>
+          <div class="avatar"><img loading="eager" decoding="async" src="assets/leaders/leader-1.jpg" alt="Chief Patron"></div>
         <div class="info"><h4>Chief Patron</h4><p class="name">Loading...</p><a class="chip" href="#">Read Message</a></div>
       </article>
       <article class="leader" data-info="assets/leaders/leader-2.txt">
-        <div class="avatar"><img loading="lazy" decoding="async" src="assets/leaders/leader-2.jpg" alt="Chairman"></div>
+          <div class="avatar"><img loading="eager" decoding="async" src="assets/leaders/leader-2.jpg" alt="Chairman"></div>
         <div class="info"><h4>Chairman</h4><p class="name">Loading...</p><a class="chip" href="#">Read Message</a></div>
       </article>
       <article class="leader" data-info="assets/leaders/leader-3.txt">
-        <div class="avatar"><img loading="lazy" decoding="async" src="assets/leaders/leader-3.jpg" alt="Principal"></div>
+          <div class="avatar"><img loading="eager" decoding="async" src="assets/leaders/leader-3.jpg" alt="Principal"></div>
         <div class="info"><h4>Principal</h4><p class="name">Loading...</p><a class="chip" href="#">Read Message</a></div>
       </article>
     </div>
@@ -127,7 +127,7 @@
 </section>
   <div class="divider wave" aria-hidden="true"></div>
 
-  <section id="achievements" class="section"><div class="wrap"><div class="head"><h2>Achievements</h2><span class="muted">Be a Champion</span></div><p class="section-desc">বছরের পর বছর প্রতিযোগিতায় সাফল্য ও শিক্ষা ক্ষেত্রে অসামান্য অর্জনের মাধ্যমে IPSC তার গৌরবময় ধারাবাহিকতা ধরে রেখেছে। ক্রীড়া, সংস্কৃতি, বিজ্ঞান ও প্রযুক্তির বিভিন্ন অঙ্গনে শিক্ষার্থীদের উল্লেখযোগ্য অর্জন আমাদের প্রত্যয়ের পরিচয় বহন করে।</p><div class="counters"><div class="counter"><span data-count="38">0</span><label>Competition Trophies</label></div><div class="counter"><span data-count="12">0</span><label>Active Clubs</label></div><div class="counter"><span data-count="120">0</span><label>Total Teachers</label></div></div><div class="mt-6 flex flex-col md:flex-row items-center gap-6"><img loading="lazy" decoding="async" class="rounded-xl shadow" src="assets/achievement-placeholder.png" alt="Champion team"></div></div></section>
+<section id="achievements" class="section"><div class="wrap"><div class="head"><h2>Achievements</h2><span class="muted">Be a Champion</span></div><p class="section-desc">বছরের পর বছর প্রতিযোগিতায় সাফল্য ও শিক্ষা ক্ষেত্রে অসামান্য অর্জনের মাধ্যমে IPSC তার গৌরবময় ধারাবাহিকতা ধরে রেখেছে। ক্রীড়া, সংস্কৃতি, বিজ্ঞান ও প্রযুক্তির বিভিন্ন অঙ্গনে শিক্ষার্থীদের উল্লেখযোগ্য অর্জন আমাদের প্রত্যয়ের পরিচয় বহন করে।</p><div class="counters"><div class="counter"><span data-count="38">0</span><label>Competition Trophies</label></div><div class="counter"><span data-count="12">0</span><label>Active Clubs</label></div><div class="counter"><span data-count="120">0</span><label>Total Teachers</label></div></div><div class="mt-6 flex flex-col md:flex-row items-center gap-6"><img loading="eager" decoding="async" class="rounded-xl shadow" src="assets/achievement-placeholder.png" alt="Champion team"></div></div></section>
   <div class="divider wave flip" aria-hidden="true"></div>
   <section id="teachers" class="section">
     <div class="wrap">
@@ -210,25 +210,25 @@
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 justify-items-center">
         <div class="w-40 sm:w-48 md:w-56 lg:w-64 bg-red-600 text-white rounded-xl shadow-lg shadow-black/40 overflow-hidden flex flex-col">
           <div class="p-2 w-full h-40 sm:h-48 md:h-56 lg:h-64 flex items-center justify-center">
-            <img loading="lazy" decoding="async" src="assets/houses/red.jpg" alt="Nazrul Islam" class="max-w-full max-h-full object-contain">
+              <img loading="eager" decoding="async" src="assets/houses/red.jpg" alt="Nazrul Islam" class="max-w-full max-h-full object-contain">
           </div>
           <div class="text-center p-2 font-semibold text-sm">Nazrul Islam House</div>
         </div>
         <div class="w-40 sm:w-48 md:w-56 lg:w-64 bg-green-600 text-white rounded-xl shadow-lg shadow-black/40 overflow-hidden flex flex-col">
           <div class="p-2 w-full h-40 sm:h-48 md:h-56 lg:h-64 flex items-center justify-center">
-            <img loading="lazy" decoding="async" src="assets/houses/green.jpg" alt="Qudrat E Khuda" class="max-w-full max-h-full object-contain">
+              <img loading="eager" decoding="async" src="assets/houses/green.jpg" alt="Qudrat E Khuda" class="max-w-full max-h-full object-contain">
           </div>
           <div class="text-center p-2 font-semibold text-sm">Qudrat E Khuda House</div>
         </div>
         <div class="w-40 sm:w-48 md:w-56 lg:w-64 bg-yellow-500 text-white rounded-xl shadow-lg shadow-black/40 overflow-hidden flex flex-col">
           <div class="p-2 w-full h-40 sm:h-48 md:h-56 lg:h-64 flex items-center justify-center">
-            <img loading="lazy" decoding="async" src="assets/houses/yellow.jpg" alt="Fozlul Haque" class="max-w-full max-h-full object-contain">
+              <img loading="eager" decoding="async" src="assets/houses/yellow.jpg" alt="Fozlul Haque" class="max-w-full max-h-full object-contain">
           </div>
           <div class="text-center p-2 font-semibold text-sm">Fozlul Haque House</div>
         </div>
         <div class="w-40 sm:w-48 md:w-56 lg:w-64 bg-orange-600 text-white rounded-xl shadow-lg shadow-black/40 overflow-hidden flex flex-col">
           <div class="p-2 w-full h-40 sm:h-48 md:h-56 lg:h-64 flex items-center justify-center">
-            <img loading="lazy" decoding="async" src="assets/houses/orange.jpg" alt="Begum Rokeya" class="max-w-full max-h-full object-contain">
+              <img loading="eager" decoding="async" src="assets/houses/orange.jpg" alt="Begum Rokeya" class="max-w-full max-h-full object-contain">
           </div>
           <div class="text-center p-2 font-semibold text-sm">Begum Rokeya House</div>
         </div>


### PR DESCRIPTION
## Summary
- Match solar system dropdown menus with dark background
- Load homepage images eagerly so sections are ready immediately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53be1b7f4832ba5855c006751dee5