### PR TITLE
Enable zoom for planetary 3D models

### DIFF
--- a/frontend/pages/solar-system.html
+++ b/frontend/pages/solar-system.html
@@ -146,7 +146,7 @@
         <div class="space-items space-y-16">
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet sun"><model-viewer src="../assets/planets/sun/sun.gltf" alt="Sun" auto-rotate rotation-per-second="30deg" exposure="1.2" camera-controls disable-zoom loading="eager"></model-viewer></div>
+              <div class="planet sun"><model-viewer src="../assets/planets/sun/sun.gltf" alt="Sun" auto-rotate rotation-per-second="30deg" exposure="1.2" camera-controls loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Sun</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -155,7 +155,7 @@
           </div>
           <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet mercury"><model-viewer src="../assets/planets/mercury/mercury.gltf" alt="Mercury" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
+              <div class="planet mercury"><model-viewer src="../assets/planets/mercury/mercury.gltf" alt="Mercury" auto-rotate camera-controls loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Mercury</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -164,7 +164,7 @@
           </div>
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet venus"><model-viewer src="../assets/planets/venus/venus.gltf" alt="Venus" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
+              <div class="planet venus"><model-viewer src="../assets/planets/venus/venus.gltf" alt="Venus" auto-rotate camera-controls loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Venus</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -173,7 +173,7 @@
           </div>
           <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet earth"><model-viewer src="../assets/planets/earth/earth.gltf" alt="Earth" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
+              <div class="planet earth"><model-viewer src="../assets/planets/earth/earth.gltf" alt="Earth" auto-rotate camera-controls loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Earth</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -182,7 +182,7 @@
           </div>
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet mars"><model-viewer src="../assets/planets/mars/mars.gltf" alt="Mars" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
+              <div class="planet mars"><model-viewer src="../assets/planets/mars/mars.gltf" alt="Mars" auto-rotate camera-controls loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Mars</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -191,7 +191,7 @@
           </div>
           <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet jupiter"><model-viewer src="../assets/planets/jupiter/jupiter.gltf" alt="Jupiter" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
+              <div class="planet jupiter"><model-viewer src="../assets/planets/jupiter/jupiter.gltf" alt="Jupiter" auto-rotate camera-controls loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Jupiter</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -201,7 +201,7 @@
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
               <div class="planet saturn">
-                <model-viewer src="../assets/planets/saturn/saturn_particles.gltf" alt="Saturn" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer>
+                <model-viewer src="../assets/planets/saturn/saturn_particles.gltf" alt="Saturn" auto-rotate camera-controls loading="eager"></model-viewer>
               </div>
               <h3 class="text-2xl font-bold mt-2">Saturn</h3>
             </div>
@@ -211,7 +211,7 @@
           </div>
           <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet uranus"><model-viewer src="../assets/planets/uranus/uranus.gltf" alt="Uranus" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
+              <div class="planet uranus"><model-viewer src="../assets/planets/uranus/uranus.gltf" alt="Uranus" auto-rotate camera-controls loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Uranus</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -220,7 +220,7 @@
           </div>
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet neptune"><model-viewer src="../assets/planets/neptune/neptune.gltf" alt="Neptune" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
+              <div class="planet neptune"><model-viewer src="../assets/planets/neptune/neptune.gltf" alt="Neptune" auto-rotate camera-controls loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Neptune</h3>
             </div>
             <p class="max-w-md text-justify">


### PR DESCRIPTION
## Summary
- Allow zooming on solar system 3D models by removing `disable-zoom` from all `<model-viewer>` elements

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c53cebd9b4832b94db2ab87150e0fa