### PR TITLE
Disable 3D model zoom and enlarge planet sizes

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -159,7 +159,7 @@ body.space-mode .mob .msub .mlink{border-color:rgba(255,255,255,.2)}
 #space .planet{position:relative;border-radius:50%;overflow:hidden}
 #space .planet::before{content:none}
 #space .planet model-viewer{width:100%;height:100%;background:transparent}
-#space .sun{width:160px;height:160px;overflow:visible;position:relative}
+#space .sun{width:200px;height:200px;overflow:visible;position:relative}
 #space .sun::before{
   content:"";
   position:absolute;
@@ -174,14 +174,14 @@ body.space-mode .mob .msub .mlink{border-color:rgba(255,255,255,.2)}
   0%,100%{transform:scale(1);opacity:.8}
   50%{transform:scale(1.15);opacity:1}
 }
-#space .mercury{width:160px;height:160px}
-#space .venus{width:160px;height:160px}
-#space .earth{width:160px;height:160px}
-#space .mars{width:160px;height:160px}
-#space .jupiter{width:160px;height:160px}
-#space .saturn{width:240px;height:240px}
-#space .uranus{width:160px;height:160px}
-#space .neptune{width:160px;height:160px}
+#space .mercury{width:200px;height:200px}
+#space .venus{width:200px;height:200px}
+#space .earth{width:200px;height:200px}
+#space .mars{width:200px;height:200px}
+#space .jupiter{width:200px;height:200px}
+#space .saturn{width:300px;height:300px}
+#space .uranus{width:200px;height:200px}
+#space .neptune{width:200px;height:200px}
 #space .item{margin:3rem 0}
 
 #space .item p{flex:1;max-width:60ch;background:transparent}

--- a/frontend/pages/solar-system.html
+++ b/frontend/pages/solar-system.html
@@ -146,7 +146,7 @@
         <div class="space-items space-y-16">
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet sun"><model-viewer src="../assets/planets/sun/sun.gltf" alt="Sun" auto-rotate rotation-per-second="30deg" exposure="1.2" camera-controls loading="eager"></model-viewer></div>
+              <div class="planet sun"><model-viewer src="../assets/planets/sun/sun.gltf" alt="Sun" auto-rotate rotation-per-second="30deg" exposure="1.2" camera-controls disable-zoom loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Sun</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -155,7 +155,7 @@
           </div>
           <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet mercury"><model-viewer src="../assets/planets/mercury/mercury.gltf" alt="Mercury" auto-rotate camera-controls loading="eager"></model-viewer></div>
+              <div class="planet mercury"><model-viewer src="../assets/planets/mercury/mercury.gltf" alt="Mercury" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Mercury</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -164,7 +164,7 @@
           </div>
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet venus"><model-viewer src="../assets/planets/venus/venus.gltf" alt="Venus" auto-rotate camera-controls loading="eager"></model-viewer></div>
+              <div class="planet venus"><model-viewer src="../assets/planets/venus/venus.gltf" alt="Venus" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Venus</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -173,7 +173,7 @@
           </div>
           <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet earth"><model-viewer src="../assets/planets/earth/earth.gltf" alt="Earth" auto-rotate camera-controls loading="eager"></model-viewer></div>
+              <div class="planet earth"><model-viewer src="../assets/planets/earth/earth.gltf" alt="Earth" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Earth</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -182,7 +182,7 @@
           </div>
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet mars"><model-viewer src="../assets/planets/mars/mars.gltf" alt="Mars" auto-rotate camera-controls loading="eager"></model-viewer></div>
+              <div class="planet mars"><model-viewer src="../assets/planets/mars/mars.gltf" alt="Mars" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Mars</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -191,7 +191,7 @@
           </div>
           <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet jupiter"><model-viewer src="../assets/planets/jupiter/jupiter.gltf" alt="Jupiter" auto-rotate camera-controls loading="eager"></model-viewer></div>
+              <div class="planet jupiter"><model-viewer src="../assets/planets/jupiter/jupiter.gltf" alt="Jupiter" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Jupiter</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -201,7 +201,7 @@
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
               <div class="planet saturn">
-                <model-viewer src="../assets/planets/saturn/saturn_particles.gltf" alt="Saturn" auto-rotate camera-controls loading="eager"></model-viewer>
+                <model-viewer src="../assets/planets/saturn/saturn_particles.gltf" alt="Saturn" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer>
               </div>
               <h3 class="text-2xl font-bold mt-2">Saturn</h3>
             </div>
@@ -211,7 +211,7 @@
           </div>
           <div class="item flex flex-col md:flex-row-reverse items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet uranus"><model-viewer src="../assets/planets/uranus/uranus.gltf" alt="Uranus" auto-rotate camera-controls loading="eager"></model-viewer></div>
+              <div class="planet uranus"><model-viewer src="../assets/planets/uranus/uranus.gltf" alt="Uranus" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Uranus</h3>
             </div>
             <p class="max-w-md text-justify">
@@ -220,7 +220,7 @@
           </div>
           <div class="item flex flex-col md:flex-row items-center gap-8">
             <div class="flex flex-col items-center text-center">
-              <div class="planet neptune"><model-viewer src="../assets/planets/neptune/neptune.gltf" alt="Neptune" auto-rotate camera-controls loading="eager"></model-viewer></div>
+              <div class="planet neptune"><model-viewer src="../assets/planets/neptune/neptune.gltf" alt="Neptune" auto-rotate camera-controls disable-zoom loading="eager"></model-viewer></div>
               <h3 class="text-2xl font-bold mt-2">Neptune</h3>
             </div>
             <p class="max-w-md text-justify">


### PR DESCRIPTION
## Summary
- Disable user zoom on solar system model-viewer elements
- Increase planet model dimensions for clearer viewing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c553281a74832b97518b45910da026