### PR TITLE
Offset Saturn ring meshes to prevent mobile z-fighting

### DIFF
--- a/frontend/assets/planets/saturn/saturn_with_rings.gltf
+++ b/frontend/assets/planets/saturn/saturn_with_rings.gltf
@@ -353,15 +353,30 @@
     },
     {
       "name": "RingC",
-      "mesh": 1
+      "mesh": 1,
+      "translation": [
+        0,
+        0,
+        0.002
+      ]
     },
     {
       "name": "RingB",
-      "mesh": 2
+      "mesh": 2,
+      "translation": [
+        0,
+        0,
+        0.001
+      ]
     },
     {
       "name": "RingA",
-      "mesh": 3
+      "mesh": 3,
+      "translation": [
+        0,
+        0,
+        -0.001
+      ]
     }
   ],
   "buffers": [


### PR DESCRIPTION
## Summary
- Offset Saturn's individual ring meshes slightly along the Z-axis to eliminate z-fighting artifacts on mobile GPUs.

## Testing
- `npx gltf-validator frontend/assets/planets/saturn/saturn_with_rings.gltf` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68c57031b4d8832b8388b3f6cbea8a4e