### PR TITLE
feat: widen HTML editor layout

### DIFF
--- a/frontend/pages/html-editor.html
+++ b/frontend/pages/html-editor.html
@@ -88,16 +88,13 @@
 </div>
 
 <section class="section">
-  <div class="wrap">
-    <div class="text-center mb-8">
-      <h1 class="grad text-4xl font-extrabold leading-tight">HTML Editor</h1>
-      <p class="mt-2 text-lg text-gray-700">Create and experiment with HTML.</p>
-    </div>
+  <div class="px-4 md:px-8">
+    <h1 class="text-2xl font-semibold mb-4">HTML Editor</h1>
     <div class="mb-4 flex items-center justify-between">
       <label class="flex items-center gap-2">
         <input id="liveToggle" type="checkbox" class="sr-only peer">
         <div class="w-10 h-5 bg-gray-300 rounded-full peer-checked:bg-green-500 relative transition-colors">
-          <div class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform peer-checked:translate-x-5"></div>
+          <div class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform transform translate-x-0 peer-checked:translate-x-5"></div>
         </div>
         <span>Live update</span>
       </label>


### PR DESCRIPTION
## Summary
- Remove large heading and allow full-width layout for the HTML editor page
- Fix live preview toggle so knob moves when switching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c57ea79d80832ba2a609722b1b8b1a