### PR TITLE
fix: rework c/c++ editor execution

### DIFF
--- a/frontend/pages/c-editor.html
+++ b/frontend/pages/c-editor.html
@@ -87,6 +87,7 @@
 
 <main class="flex flex-col" style="height:calc(100vh - var(--mast-h));">
   <div class="flex items-center justify-end p-2 gap-2">
+      <input id="stdinField" class="border rounded px-2 py-1 text-sm" placeholder="Input (optional)" />
       <select id="langSelect" class="border rounded px-2 py-1 text-sm">
         <option value="c">C</option>
         <option value="c++">C++</option>
@@ -105,9 +106,6 @@
       <button id="closeConsole" class="text-sm px-2">✖</button>
     </div>
     <textarea id="consoleArea" class="flex-1 w-full p-2 font-mono text-sm bg-black text-green-200 overflow-auto" readonly></textarea>
-    <div class="p-2 border-t">
-      <input id="stdinField" class="w-full p-2 font-mono text-sm border rounded" placeholder="Enter input and press Enter" />
-    </div>
   </div>
 </div>
 
@@ -136,7 +134,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function showConsole(){
     consoleModal.classList.remove('hidden');
-    stdinField.focus();
   }
 
   function hideConsole(){
@@ -145,62 +142,52 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function clearErrors(){ cm.clearGutter('error-gutter'); }
 
-  let ws;
-
-  function startExecution(){
+  async function runCode(){
     const language = langSelect.value;
     const filename = language === 'c' ? 'main.c' : 'main.cpp';
     const code = cm.getValue();
-    consoleArea.value = '';
+    const stdin = stdinField.value;
+    consoleArea.value = 'Running...\n';
     clearErrors();
-    ws = new WebSocket('wss://emkc.org/api/v2/piston/execute');
-    ws.addEventListener('open', () => {
-      ws.send(JSON.stringify({ language, version: '10.2.0', files: [{ name: filename, content: code }] }));
-    });
-    ws.addEventListener('message', evt => {
-      try {
-        const msg = JSON.parse(evt.data);
-        if(msg.stdout){ consoleArea.value += msg.stdout; }
-        if(msg.stderr){ consoleArea.value += msg.stderr; }
-        if(msg.exit != null){ consoleArea.value += `\nProcess exited with code ${msg.exit}`; ws.close(); }
-        if(msg.compile_output){
-          consoleArea.value += msg.compile_output;
-          const regex = /main\.(?:c|cpp):(\d+):/g;
-          let match;
-          while((match = regex.exec(msg.compile_output)) !== null){
-            const line = parseInt(match[1],10);
-            const marker = document.createElement('div');
-            marker.className = 'error-marker';
-            marker.textContent = '●';
-            cm.setGutterMarker(line-1,'error-gutter',marker);
-          }
+    showConsole();
+    try {
+      const res = await fetch('https://emkc.org/api/v2/piston/execute', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          language,
+          version: '10.2.0',
+          files: [{ name: filename, content: code }],
+          stdin
+        })
+      });
+      const data = await res.json();
+      if(data.compile && data.compile.stderr){
+        consoleArea.value += data.compile.stderr;
+        const regex = /main\.(?:c|cpp):(\d+):/g;
+        let match;
+        while((match = regex.exec(data.compile.stderr)) !== null){
+          const line = parseInt(match[1],10);
+          const marker = document.createElement('div');
+          marker.className = 'error-marker';
+          marker.textContent = '●';
+          cm.setGutterMarker(line-1,'error-gutter',marker);
         }
-      } catch(e){ consoleArea.value += evt.data; }
-    });
-    ws.addEventListener('close', () => { ws = null; });
+      }
+      if(data.run){
+        if(data.run.stdout){ consoleArea.value += data.run.stdout; }
+        if(data.run.stderr){ consoleArea.value += data.run.stderr; }
+        if(data.run.code !== undefined){ consoleArea.value += `\nProcess exited with code ${data.run.code}`; }
+      }
+    } catch(err){
+      consoleArea.value += 'Error: ' + err.message;
+    }
   }
 
-  runBtn?.addEventListener('click', () => {
-    consoleArea.value='';
-    stdinField.value='';
-    showConsole();
-    startExecution();
-  });
-
-  stdinField?.addEventListener('keydown', e => {
-    if(e.key === 'Enter' && ws){
-      e.preventDefault();
-      ws.send(stdinField.value + '\n');
-      stdinField.value='';
-    }
-  });
-
-  closeConsole?.addEventListener('click', () => {
-    if(ws){ ws.close(); }
-    hideConsole();
-  });
+  runBtn?.addEventListener('click', runCode);
+  closeConsole?.addEventListener('click', hideConsole);
   ['contextmenu','selectstart','dragstart','copy','cut'].forEach(evt=>{
-    cm.getWrapperElement().addEventListener(evt,e=>e.stopPropagation());
+    cm.getWrapperElement().addEventListener(evt, e => e.stopPropagation());
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- use HTTP fetch for Piston API execution
- display compile errors with line markers
- support optional stdin input before running

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c592c622f0832b9d85b283bfd583d8