### PR TITLE
Fix HTML editor preview update

### DIFF
--- a/frontend/pages/html-editor.html
+++ b/frontend/pages/html-editor.html
@@ -124,7 +124,7 @@
       gutters: ['CodeMirror-linenumbers','error-gutter']
     });
     const editorWrap = cm.getWrapperElement();
-    editorWrap.className = editorText.className;
+    editorText.classList.forEach(cls => editorWrap.classList.add(cls));
 
     cm.on('cursorActivity', () => {
       const coords = cm.cursorCoords(null, 'local');
@@ -139,15 +139,17 @@
 
     function showErrors(){
       clearErrors();
-      const errs = HTMLHint.verify(cm.getValue());
-      errs.forEach(e => {
-        const line = e.line - 1;
-        const marker = document.createElement('div');
-        marker.className = 'error-marker';
-        marker.textContent = '●';
-        cm.setGutterMarker(line,'error-gutter',marker);
-        cm.addLineClass(line,'background','error-line');
-      });
+      if(window.HTMLHint){
+        const errs = HTMLHint.verify(cm.getValue());
+        errs.forEach(e => {
+          const line = e.line - 1;
+          const marker = document.createElement('div');
+          marker.className = 'error-marker';
+          marker.textContent = '●';
+          cm.setGutterMarker(line,'error-gutter',marker);
+          cm.addLineClass(line,'background','error-line');
+        });
+      }
     }
 
     const update = () => {


### PR DESCRIPTION
## Summary
- Preserve CodeMirror wrapper classes to maintain editor styling
- Guard HTMLHint usage so preview updates even when library is unavailable

## Testing
- no tests

------
https://chatgpt.com/codex/tasks/task_e_68c59eae5270832b964e82a210d97586