### PR TITLE
Speed up result card timer

### DIFF
--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -304,7 +304,7 @@ function initCommon(){
       if(e.isIntersecting){
         const el=e.target,end=parseInt(el.dataset.count,10);
         let start=null;
-        const duration=2500;
+        const duration=1500;
         const step=t=>{
           if(start===null) start=t;
           const progress=Math.min((t-start)/duration,1);


### PR DESCRIPTION
## Summary
- Speed up SSC/HSC result card counters for a snappier reveal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ac47aa98832b9808164a13dd89c5