### PR TITLE
Remove celebratory animations from exam result cards

### DIFF
--- a/frontend/components/common.css
+++ b/frontend/components/common.css
@@ -116,11 +116,7 @@
     .fade-bottom{position:absolute;bottom:0;left:0;width:100%;height:50%;pointer-events:none;background:linear-gradient(to bottom,rgba(248,250,252,0),#f8fafc)}
     .result-card{position:relative;overflow:hidden;background-color:rgba(255,255,255,.3);backdrop-filter:blur(4px);min-height:12rem}
     .result-card::before{content:attr(data-label);position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:clamp(7rem,18vw,16rem);font-weight:900;font-family:'Poppins',sans-serif;letter-spacing:.5rem;color:rgba(15,23,42,.1);pointer-events:none;text-transform:uppercase}
-    .rate{transition:color .2s}
-    .rate.celebrate{animation:yay .8s ease}
-    @keyframes yay{0%{transform:scale(1)}50%{transform:scale(1.4)}100%{transform:scale(1)}}
-    .particle{position:fixed;width:6px;height:6px;background:var(--color);opacity:.9;pointer-events:none;border-radius:50%;will-change:transform;transform:translate3d(0,0,0)}
-      #gallery .carousel{position:relative;width:100%;max-width:900px;aspect-ratio:16/9;margin:0 auto;overflow:hidden}
+    #gallery .carousel{position:relative;width:100%;max-width:900px;aspect-ratio:16/9;margin:0 auto;overflow:hidden}
       #gallery .carousel::before,#gallery .carousel::after{content:"";position:absolute;top:0;bottom:0;width:10%;pointer-events:none;z-index:4}
       #gallery .carousel::before{left:0;background:linear-gradient(to right,#f8fafc,rgba(248,250,252,0))}
       #gallery .carousel::after{right:0;background:linear-gradient(to left,#f8fafc,rgba(248,250,252,0))}

--- a/frontend/components/common.js
+++ b/frontend/components/common.js
@@ -310,22 +310,8 @@ function initCommon(){
           const progress=Math.min((t-start)/duration,1);
           const val=Math.floor(progress*end);
           el.textContent=val;
-          if(progress<0.33){
-            el.classList.add('text-yellow-500');
-            el.classList.remove('text-green-600','text-red-600');
-          }else if(progress<0.66){
-            el.classList.add('text-green-600');
-            el.classList.remove('text-yellow-500','text-red-600');
-          }else{
-            el.classList.add('text-red-600');
-            el.classList.remove('text-yellow-500','text-green-600');
-          }
           if(progress<1){
             requestAnimationFrame(step);
-          }else{
-            el.classList.add('celebrate');
-            gsap.fromTo(el,{scale:1.4},{scale:1,duration:.6,ease:'bounce.out'});
-            launchConfetti(el);
           }
         };
         requestAnimationFrame(step);
@@ -334,49 +320,6 @@ function initCommon(){
     });
   },{threshold:.2});
   rates.forEach(r=>rateIO.observe(r));
-
-    function launchConfetti(el){
-      const card=el.closest('.result-card');
-      if(!card) return;
-      const rect=card.getBoundingClientRect();
-      const originX=rect.left+rect.width/2;
-      const originY=rect.top+rect.height/2;
-      const frag=document.createDocumentFragment();
-      const particles=[];
-      const count=40;
-      for(let i=0;i<count;i++){
-        const s=document.createElement('span');
-        s.className='particle';
-        const size=4+Math.random()*4;
-        s.style.width=s.style.height=size+'px';
-        s.style.left=originX+'px';
-        s.style.top=originY+'px';
-        s.style.setProperty('--color',randomColor());
-        particles.push(s);
-        frag.appendChild(s);
-      }
-      document.body.appendChild(frag);
-      particles.forEach(s=>{
-        const angle=Math.random()*Math.PI*2;
-        const dist=120+Math.random()*180;
-        const dx=Math.cos(angle)*dist;
-        const dy=Math.sin(angle)*dist;
-        const bend=Math.random()*60-30;
-        const path=[
-          {x:0,y:0},
-          {x:dx/2+bend,y:dy/2-(40+Math.random()*40)},
-          {x:dx,y:dy},
-          {x:dx+bend*0.5,y:dy+600}
-        ];
-        gsap.to(s,{motionPath:{path,curviness:1.25},duration:3,ease:'power1.inOut',onComplete:()=>s.remove()});
-        gsap.to(s,{rotation:()=>Math.random()*360,repeat:-1,duration:1,ease:'linear'});
-      });
-    }
-
-  function randomColor(){
-    const h=Math.floor(Math.random()*360);
-    return `hsl(${h},70%,60%)`;
-  }
   document.querySelectorAll('.strip.loop').forEach(strip=>{
     const kids=[...strip.children];
     kids.forEach(el=>strip.appendChild(el.cloneNode(true)));


### PR DESCRIPTION
## Summary
- strip color-change and confetti effects from SSC/HSC result counters
- drop unused celebration styles from CSS

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ipsc.edu.bd/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c5ae35a638832bb21f5dfaa52a56a9